### PR TITLE
Fixed to pass PHP strict standards

### DIFF
--- a/lib/Resque/Failure.php
+++ b/lib/Resque/Failure.php
@@ -35,7 +35,7 @@ class Resque_Failure
 	 *
 	 * @return object Instance of backend object.
 	 */
-	public function getBackend()
+	public static function getBackend()
 	{
 		if(self::$backend === null) {
 			require  dirname(__FILE__) . '/Failure/Redis.php';
@@ -52,7 +52,7 @@ class Resque_Failure
 	 *
 	 * @param string $backend The class name of the backend to pipe failures to.
 	 */
-	public function setBackend($backend)
+	public static function setBackend($backend)
 	{
 		self::$backend = $backend;
 	}

--- a/lib/Resque/Stat.php
+++ b/lib/Resque/Stat.php
@@ -15,7 +15,7 @@ class Resque_Stat
 	 * @param string $stat The name of the statistic to get the stats for.
 	 * @return mixed Value of the statistic.
 	 */
-	public function get($stat)
+	public static function get($stat)
 	{
 		return (int)Resque::redis()->get('stat:' . $stat);
 	}
@@ -27,7 +27,7 @@ class Resque_Stat
 	 * @param int $by The amount to increment the statistic by.
 	 * @return boolean True if successful, false if not.
 	 */
-	public function incr($stat, $by = 1)
+	public static function incr($stat, $by = 1)
 	{
 		return (bool)Resque::redis()->incrby('stat:' . $stat, $by);
 	}
@@ -39,7 +39,7 @@ class Resque_Stat
 	 * @param int $by The amount to decrement the statistic by.
 	 * @return boolean True if successful, false if not.
 	 */
-	public function decr($stat, $by = 1)
+	public static function decr($stat, $by = 1)
 	{
 		return (bool)Resque::redis()->decrby('stat:' . $stat, $by);
 	}
@@ -50,7 +50,7 @@ class Resque_Stat
 	 * @param string $stat The name of the statistic to delete.
 	 * @return boolean True if successful, false if not.
 	 */
-	public function clear($stat)
+	public static function clear($stat)
 	{
 		return (bool)Resque::redis()->del('stat:' . $stat);
 	}


### PR DESCRIPTION
We've been using your awesome library to use Resque in PHP. However, since some of your classes didn't pass PHP strict standards, a lot of our tests would fail or output notices. I've simply patched the relevant parts of code to make this work (just making `static` methods actually `static`).

Hope it helps!

Stephen
