### PR TITLE
Job::updateStatus() never works - Failing Tests

### DIFF
--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -91,7 +91,7 @@ class Resque_Job
 	 */
 	public function updateStatus($status)
 	{
-		if(empty($this->payload->id)) {
+		if(empty($this->payload['id'])) {
 			return;
 		}
 


### PR DESCRIPTION
This addresses the following issue:

This empty check always returned true, thus job statuses were never updated. The failing unit tests also blatantly indicate this.

```
public function updateStatus($status)
{
    if(empty($this->payload->id)) {
        return;
    }

    $statusInstance = new Resque_Job_Status($this->payload['id']);
    $statusInstance->update($status);
}
```
