### PR TITLE
Test reliability

### DIFF
--- a/test/Resque/Tests/bootstrap.php
+++ b/test/Resque/Tests/bootstrap.php
@@ -59,7 +59,7 @@ function killRedis($pid)
 
 	$pidFile = TEST_MISC . '/' . $matches[1];
 	$pid = trim(file_get_contents($pidFile));
-	posix_kill($pid, 9);
+	posix_kill((int) $pid, 9);
 
 	if(is_file($pidFile)) {
 		unlink($pidFile);


### PR DESCRIPTION
This branch addresses three issues:
1. Introduces a half-second usleep() delay after starting redis-server. This prevents speedy machines from attempting to connect before the server has even started, causing test failure.
2. The killRedis() shutdown function now compares the calling PID with the PID of the running PHPUnit process (parent). Without this, when a worker child process exits, the shutdown function is called.
3. The PID passed to posix_kill() is now type cast to an int
