### PR TITLE
Just a quick update to the readme.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -47,7 +47,7 @@ Jobs are queued as follows:
     require_once 'lib/Resque.php';
 
 	// Required if redis is located elsewhere
-	Resque::setBackend('localhost', 6379);
+	Resque::setBackend('localhost:6379');
 
 	$args = array(
 		'name' => 'Chris'


### PR DESCRIPTION
updated readme example of how to setBackend to use a single param with a colon for server:port rather than two separate variables
