### PR TITLE
Ruby resque-web compatibility improvement

### DIFF
--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -128,7 +128,7 @@ class Resque_Job
 			return array();
 		}
 		
-		return array_shift($this->payload['args']);
+		return $this->payload['args'][0];
 	}
 	
 	/**


### PR DESCRIPTION
Currently the Ruby version of resque wraps the job args in an array when pushing it onto the queue and php-resque doesn't. The consequence of this is that if you attempt to retry a failed job using the Ruby resque-web interface it mangles the payload/args by type casting them to a numerically indexed array before requeueing.

This patch simply wraps the job args in an array and unwraps them when the job starts to allow resque-web retry functionality to work as expected. No changes are required from a php-resque user's perspective, just be aware that if this patch is applied and workers restarted while pre-existing jobs are on the queue all those jobs will fail.
