### PR TITLE
Fix a bug where the worker would spin out of control if the redis socket is interrupted

### DIFF
--- a/lib/Redisent/Redisent.php
+++ b/lib/Redisent/Redisent.php
@@ -49,6 +49,10 @@ class Redisent {
     function __construct($host, $port = 6379) {
         $this->host = $host;
         $this->port = $port;
+				$this->establishConnection();
+    }
+
+    function establishConnection() {
         $this->__sock = fsockopen($this->host, $this->port, $errno, $errstr);
         if (!$this->__sock) {
             throw new Exception("{$errno} - {$errstr}");


### PR DESCRIPTION
Fix a bug where the worker would spin out of control taking the server with it, if the redis connection was interrupted even briefly. Use SIGPIPE to trap this scenario cleanly.

As per my bug report.  Here is a fix.  It's quite easy to deliberately cause this situation and check it out.

I haven't moved the usleep() call, which was my other suggestion as a way to minimize the impact of such errors, but you may wish to consider it.

I have some other changes on my fork that are probably worth contributing back, but I've probably changed too much on master so will have to pick through them.  They mostly surround how the forked children are managed... we've created the equivalent of resque-pool (from ruby) and it wasn't capable to shutting down the workers due to the way they were handling `pcntl_waitpid()` without WNOHANG.

This patch is critical, however :)
