### PR TITLE
Child batch

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -155,8 +155,6 @@ class Resque_Worker
 		$this->id = $this->hostname . ':'.getmypid() . ':' . implode(',', $this->queues);
 
         $this->perChild = $perChild;
-
-        echo "LOG (".getmypid().")-- construct with $perChild per child\n";
 	}
 
 	/**

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -138,7 +138,7 @@ class Resque_Worker
 	 * @param string|array $queues String with a single queue name, array with multiple.
      * @param int $perChild How many jobs to perform per child
 	 */
-	public function __construct($queues, $perChild)
+	public function __construct($queues, $perChild = 1)
 	{
 		if(!is_array($queues)) {
 			$queues = array($queues);
@@ -155,6 +155,8 @@ class Resque_Worker
 		$this->id = $this->hostname . ':'.getmypid() . ':' . implode(',', $this->queues);
 
         $this->perChild = $perChild;
+
+        echo "LOG (".getmypid().")-- construct with $perChild per child\n";
 	}
 
 	/**
@@ -331,7 +333,7 @@ class Resque_Worker
 		}
 
         // if we are the child
-        if ($this->child === 0) {
+        if ($this->child === 0 || $this->child === false) {
 
             // if we're meant to carry on in the same fork
             if ($this->processedInChild > 0 && $this->processedInChild < $this->perChild) {
@@ -342,7 +344,6 @@ class Resque_Worker
             // otherwise we die and let the parent deal with the situation below
             exit(0);
         } else {
-            
             // if we pass test above, fork and reset
             $this->processedInChild = 1; // theoretically this is unnecessary, since it's only incremented in the child which doesn't affect the parent
 

--- a/resque.php
+++ b/resque.php
@@ -44,6 +44,12 @@ if(!empty($COUNT) && $COUNT > 1) {
 	$count = $COUNT;
 }
 
+$perChild = 1;
+$PERCHILD = getenv('PERCHILD');
+if(!empty($PERCHILD) && $PERCHILD > 1) {
+	$perChild = $PERCHILD;
+}
+
 if($count > 1) {
 	for($i = 0; $i < $count; ++$i) {
 		$pid = pcntl_fork();
@@ -53,7 +59,7 @@ if($count > 1) {
 		// Child, start the worker
 		else if(!$pid) {
 			$queues = explode(',', $QUEUE);
-			$worker = new Resque_Worker($queues);
+			$worker = new Resque_Worker($queues, $perChild);
 			$worker->logLevel = $logLevel;
 			fwrite(STDOUT, '*** Starting worker '.$worker."\n");
 			$worker->work($interval);
@@ -64,7 +70,7 @@ if($count > 1) {
 // Start a single worker
 else {
 	$queues = explode(',', $QUEUE);
-	$worker = new Resque_Worker($queues);
+	$worker = new Resque_Worker($queues, $perChild);
 	$worker->logLevel = $logLevel;
 	
 	$PIDFILE = getenv('PIDFILE');


### PR DESCRIPTION
Workers will now accept a PERCHILD env variable. This will process multiple jobs in each child to reduce the amount of forks and drastically improve performance. Not setting the variable, or having a value of 1, is equivalent to the previous behaviors.

Did not write unit tests, but did document in comments and did adhere to code style used.

Deployed this in production in our (chartboost.com) high-traffic (1k jobs per second) environment and is running smoothly so far. Will report back tomorrow if anything is new.
