### PR TITLE
Avoid working with dirty worker ids

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -53,7 +53,7 @@ class Resque_Worker
 	 * @var Resque_Job Current job, if any, being processed by this worker.
 	 */
 	private $currentJob = null;
-	
+
 	/**
 	 * @var int Process ID of child worker processes.
 	 */
@@ -95,7 +95,7 @@ class Resque_Worker
 	 */
 	public static function find($workerId)
 	{
-		if(!self::exists($workerId)) {
+	  if(!self::exists($workerId) || false === strpos($workerId, ":")) {
 			return false;
 		}
 
@@ -447,12 +447,14 @@ class Resque_Worker
 		$workerPids = $this->workerPids();
 		$workers = self::all();
 		foreach($workers as $worker) {
-			list($host, $pid, $queues) = explode(':', (string)$worker, 3);
-			if($host != $this->hostname || in_array($pid, $workerPids) || $pid == getmypid()) {
-				continue;
-			}
-			$this->log('Pruning dead worker: ' . (string)$worker, self::LOG_VERBOSE);
-			$worker->unregisterWorker();
+		  if (is_object($worker)) {
+  			list($host, $pid, $queues) = explode(':', (string)$worker, 3);
+  			if($host != $this->hostname || in_array($pid, $workerPids) || $pid == getmypid()) {
+  				continue;
+  			}
+  			$this->log('Pruning dead worker: ' . (string)$worker, self::LOG_VERBOSE);
+  			$worker->unregisterWorker();
+		  }
 		}
 	}
 


### PR DESCRIPTION
Hi,
In Worker.php, when finding workers or pruning dead workers, we don't check whether the worker object is a valid worker. Sometimes, may due to some errors, the worker id is wrong leading to some notices being thrown. I added a check for it
Thanks
