### PR TITLE
Fix lost jobs in multiple workers with count > 1 (issue #32)

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -53,7 +53,7 @@ class Resque_Worker
 	 * @var Resque_Job Current job, if any, being processed by this worker.
 	 */
 	private $currentJob = null;
-	
+
 	/**
 	 * @var int Process ID of child worker processes.
 	 */
@@ -193,6 +193,9 @@ class Resque_Worker
 
 			// Forked and we're the child. Run the job.
 			if($this->child === 0 || $this->child === false) {
+			  //reconnect to Redis in child to avoid sharing same connection with parent process
+			  // leading to race condition reading from the same socket, thus errors
+			  Resque::ResetBackend();
 				$status = 'Processing ' . $job->queue . ' since ' . strftime('%F %T');
 				$this->updateProcLine($status);
 				$this->log($status, self::LOG_VERBOSE);

--- a/resque.php
+++ b/resque.php
@@ -54,6 +54,9 @@ if($count > 1) {//start multiple workers by forking this process
     }
     // Child, start the worker
     else if($pid === 0) {
+      //reconnect to Redis in child to avoid sharing same connection with parent process
+      // leading to race condition reading from the same socket, thus errors
+      Resque::ResetBackend();
       $queues = explode(',', $QUEUE);
       $worker = new Resque_Worker($queues);
       $worker->logLevel = $logLevel;


### PR DESCRIPTION
Hi,
I tracked down the issue #32. Seems it's caused by not letting the main parent process continue to live and wait for all its children to exit before exiting itself. I've also registered a shutdown function to kill the child process when exiting.
Thanks
