### PR TITLE
Ensure RedisException is not redeclared to allow PHPRedis compatibility

### DIFF
--- a/lib/Redisent/Redisent.php
+++ b/lib/Redisent/Redisent.php
@@ -11,8 +11,11 @@ define('CRLF', sprintf('%s%s', chr(13), chr(10)));
 
 /**
  * Wraps native Redis errors in friendlier PHP exceptions
+ * Only declared if class doesn't already exist to ensure compatibility with php-redis
  */
-class RedisException extends Exception {
+if (! class_exists('RedisException')) {
+    class RedisException extends Exception {
+    }
 }
 
 /**


### PR DESCRIPTION
This fixes issue #19 until a more permanent solution of renaming the RedisException class to Redisent_Exception is implemented. Otherwise users with PHPRedis installed receive an error of:

`PHP Fatal error:  Cannot redeclare class RedisException in lib/Redisent/Redisent.php on line 16`
