### PR TITLE
Disable autoload for the class_exists func

### DIFF
--- a/lib/Redisent/Redisent.php
+++ b/lib/Redisent/Redisent.php
@@ -13,7 +13,7 @@ define('CRLF', sprintf('%s%s', chr(13), chr(10)));
  * Wraps native Redis errors in friendlier PHP exceptions
  * Only declared if class doesn't already exist to ensure compatibility with php-redis
  */
-if (! class_exists('RedisException')) {
+if (! class_exists('RedisException', false)) {
     class RedisException extends Exception {
     }
 }


### PR DESCRIPTION
I ran into an autoload problem because of this class_exists function.
So I set the second arg to false to prevent it from calling __autoload.  
It doesn't make sense to try (to autoload) anyway because it's going to 
declare a skeleton if the class doesn't exist.
