### PR TITLE
Do not redefine 'CRLF' in Redis Redisent client

### DIFF
--- a/lib/Redisent/Redisent.php
+++ b/lib/Redisent/Redisent.php
@@ -7,7 +7,7 @@
  * @package Redisent
  */
 
-define('CRLF', sprintf('%s%s', chr(13), chr(10)));
+if ( !defined('CRLF') ) define('CRLF', sprintf('%s%s', chr(13), chr(10)));
 
 /**
  * Wraps native Redis errors in friendlier PHP exceptions


### PR DESCRIPTION
I'm in an environment where I use another Redis client for something else and that client also defines 'CRLF'. Added a test to not redefine it if it's already there.
