### PR TITLE
implement prefix removal

### DIFF
--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -113,5 +113,20 @@ class Resque_Redis extends Redisent
 			return false;
 		}
 	}
+
+    public static function getPrefix()
+    {
+        return self::$defaultNamespace;
+    }
+
+    public static function removePrefix($string)
+    {
+        $prefix=self::getPrefix();
+
+        if (substr($string, 0, strlen($prefix)) == $prefix) {
+            $string = substr($string, strlen($prefix), strlen($string) );
+        }
+        return $string;
+    }
 }
 ?>


### PR DESCRIPTION
Function to remove the prefix from a string.

I needed this to implement removeDelayed in php-resque-scheduler.
