### PR TITLE
Fix for lost connection infinite loop

### DIFF
--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -231,7 +231,7 @@ class Resque_Job
 			$monitor = true;
 		}
 
-		return self::create($this->queue, $this->payload['class'], $this->payload['args'][0], $monitor);
+		return self::create($this->queue, $this->payload['class'], $this->payload['args'], $monitor);
 	}
 
 	/**


### PR DESCRIPTION
Added the ability to retry establishing a connection to redis when the connection is lost. I also placed a sleep for 1 second before attempting to re-establish a connection. Our error logs were logging large amounts of the following error fwrite(): send of 51 bytes failed with errno=32 Broken pipe.
