### PR TITLE
Composer Autoload Failure

### DIFF
--- a/bin/resque
+++ b/bin/resque
@@ -4,6 +4,7 @@
 // Find and initialize Composer
 $files = array(
   __DIR__ . '/../../vendor/autoload.php',
+  __DIR__ . '/../../../autoload.php',
   __DIR__ . '/../../../../autoload.php',
   __DIR__ . '/../vendor/autoload.php',
 );


### PR DESCRIPTION
Failure to check up **3** folders when running the binary from
chrisboulton/php-resque/bin/ results in never finding the autoload
file when it tries to load up the composer dependencies.
