### PR TITLE
Improved Worker Reliability

### DIFF
--- a/bin/resque
+++ b/bin/resque
@@ -130,8 +130,10 @@ if($count > 1) {
 					
 					$PIDFILE = getenv('PIDFILE');
 					if ($PIDFILE) {
-						file_put_contents($PIDFILE, getmypid()) or
-							die('Could not write PID information to ' . $PIDFILE);
+						file_put_contents($PIDFILE, getmypid()) or (
+							$logger->log(Psr\Log\LogLevel::NOTICE, 'Could not write PID information to {pidfile}', array('pidfile' => $PIDFILE)) and
+							die(2)
+                                                    );
 					}
 					
 					$registered = TRUE;
@@ -171,11 +173,13 @@ else {
 	$worker->logLevel = $logLevel;
 	$worker->hasParent = FALSE;
 
-    $PIDFILE = getenv('PIDFILE');
-    if ($PIDFILE) {
-        file_put_contents($PIDFILE, getmypid()) or
-            die('Could not write PID information to ' . $PIDFILE);
-    }
+	$PIDFILE = getenv('PIDFILE');
+	if ($PIDFILE) {
+		file_put_contents($PIDFILE, getmypid()) or (
+			$logger->log(Psr\Log\LogLevel::NOTICE, 'Could not write PID information to {pidfile}', array('pidfile' => $PIDFILE)) and
+			die(2)
+                    );
+	}
 
     $logger->log(Psr\Log\LogLevel::NOTICE, 'Starting worker {worker}', array('worker' => $worker));
     $worker->work($interval, $BLOCKING);

--- a/bin/resque
+++ b/bin/resque
@@ -93,29 +93,83 @@ if(!empty($PREFIX)) {
     Resque_Redis::prefix($PREFIX);
 }
 
+function cleanup_children($signal){
+	$GLOBALS['send_signal'] = $signal;
+}
+
 if($count > 1) {
-    for($i = 0; $i < $count; ++$i) {
-        $pid = Resque::fork();
-        if($pid === false || pid === -1) {
-            $logger->log(Psr\Log\LogLevel::EMERGENCY, 'Could not fork worker {count}', array('count' => $i));
-            die();
-        }
-        // Child, start the worker
-        else if(!$pid) {
-            $queues = explode(',', $QUEUE);
-            $worker = new Resque_Worker($queues);
-            $worker->setLogger($logger);
-            $logger->log(Psr\Log\LogLevel::NOTICE, 'Starting worker {worker}', array('worker' => $worker));
-            $worker->work($interval, $BLOCKING);
-            break;
-        }
-    }
+	$children = array();
+	$GLOBALS['send_signal'] = FALSE;
+	
+	$die_signals = array(SIGTERM, SIGINT, SIGQUIT);
+	$all_signals = array_merge($die_signals, array(SIGUSR1, SIGUSR2, SIGCONT, SIGPIPE));
+	
+	for($i = 0; $i < $count; ++$i) {
+		$pid = Resque::fork();
+		if($pid == -1) {
+			die("Could not fork worker ".$i."\n");
+		}
+		// Child, start the worker
+		elseif(!$pid) {
+			$queues = explode(',', $QUEUE);
+			$worker = new Resque_Worker($queues);
+			$worker->logLevel = $logLevel;
+			$worker->hasParent = TRUE;
+			fwrite(STDOUT, '*** Starting worker '.$worker."\n");
+			$worker->work($interval);
+			break;
+		}
+		else {
+			$children[$pid] = 1;
+			while (count($children) == $count){
+				if (!isset($registered)) {
+					declare(ticks = 1);
+					foreach ($all_signals as $signal) {
+						pcntl_signal($signal,  "cleanup_children");
+					}
+					
+					$PIDFILE = getenv('PIDFILE');
+					if ($PIDFILE) {
+						file_put_contents($PIDFILE, getmypid()) or
+							die('Could not write PID information to ' . $PIDFILE);
+					}
+					
+					$registered = TRUE;
+				}
+				
+				if(function_exists('setproctitle')) {
+					setproctitle('resque-' . Resque::VERSION . ": Monitoring {$count} children: [".implode(',', array_keys($children))."]");
+				}
+				
+				$childPID = pcntl_waitpid(-1, $childStatus, WNOHANG);
+				if ($childPID != 0) {
+					fwrite(STDOUT, "\033[01;31m*** A child worker died: {$childPID}\033[00m\n");
+					unset($children[$childPID]);
+					$i--;					
+				}
+				usleep(250000);
+				if ($GLOBALS['send_signal'] !== FALSE){
+					foreach ($children as $k => $v){
+						posix_kill($k, $GLOBALS['send_signal']);
+						if (in_array($GLOBALS['send_signal'], $die_signals)) {
+							pcntl_waitpid($k, $childStatus);
+						}
+					}
+					if (in_array($GLOBALS['send_signal'], $die_signals)) {
+						exit;
+					}
+					$GLOBALS['send_signal'] = FALSE;
+				}
+			}
+		}
+	}
 }
 // Start a single worker
 else {
-    $queues = explode(',', $QUEUE);
-    $worker = new Resque_Worker($queues);
-    $worker->setLogger($logger);
+	$queues = explode(',', $QUEUE);
+	$worker = new Resque_Worker($queues);
+	$worker->logLevel = $logLevel;
+	$worker->hasParent = FALSE;
 
     $PIDFILE = getenv('PIDFILE');
     if ($PIDFILE) {

--- a/bin/resque
+++ b/bin/resque
@@ -130,10 +130,10 @@ if($count > 1) {
 					
 					$PIDFILE = getenv('PIDFILE');
 					if ($PIDFILE) {
-						file_put_contents($PIDFILE, getmypid()) or (
-							$logger->log(Psr\Log\LogLevel::NOTICE, 'Could not write PID information to {pidfile}', array('pidfile' => $PIDFILE)) and
-							die(2)
-                                                    );
+						if(file_put_contents($PIDFILE, getmypid()) === false){
+							$logger->log(Psr\Log\LogLevel::NOTICE, 'Could not write PID information to {pidfile}', array('pidfile' => $PIDFILE));
+                                                        die(2);
+                                                }
 					}
 					
 					$registered = TRUE;
@@ -175,10 +175,10 @@ else {
 
 	$PIDFILE = getenv('PIDFILE');
 	if ($PIDFILE) {
-		file_put_contents($PIDFILE, getmypid()) or (
-			$logger->log(Psr\Log\LogLevel::NOTICE, 'Could not write PID information to {pidfile}', array('pidfile' => $PIDFILE)) and
-			die(2)
-                    );
+		if(file_put_contents($PIDFILE, getmypid()) === false) {
+			$logger->log(Psr\Log\LogLevel::NOTICE, 'Could not write PID information to {pidfile}', array('pidfile' => $PIDFILE));
+                        die(2);
+                }
 	}
 
     $logger->log(Psr\Log\LogLevel::NOTICE, 'Starting worker {worker}', array('worker' => $worker));

--- a/bin/resque
+++ b/bin/resque
@@ -143,7 +143,7 @@ if($count > 1) {
 				
 				$childPID = pcntl_waitpid(-1, $childStatus, WNOHANG);
 				if ($childPID != 0) {
-					fwrite(STDOUT, "\033[01;31m*** A child worker died: {$childPID}\033[00m\n");
+					fwrite(STDOUT, "*** A child worker died: {$childPID}\n");
 					unset($children[$childPID]);
 					$i--;					
 				}

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -17,6 +17,11 @@ class Resque_Worker
 	public $logger;
 
 	/**
+	 * @var bool Whether this worker is running in a forked child process.
+	 */
+	public $hasParent = false;
+
+	/**
 	 * @var array Array of all associated queues for this worker.
 	 */
 	private $queues = array();
@@ -219,6 +224,14 @@ class Resque_Worker
 						'Job exited with exit code ' . $exitStatus
 					));
 				}
+				else
+				{
+					if (in_array($job->getStatus(), array(Resque_Job_Status::STATUS_WAITING, Resque_Job_Status::STATUS_RUNNING)))
+					{
+						$job->updateStatus(Resque_Job_Status::STATUS_COMPLETE);
+						$this->log('done ' . $job);
+					}
+				}
 			}
 
 			$this->child = null;
@@ -256,6 +269,12 @@ class Resque_Worker
 	 */
 	public function reserve($blocking = false, $timeout = null)
 	{
+		if ($this->hasParent && !posix_kill(posix_getppid(), 0))
+		{
+			$this->shutdown();
+			return false;
+		}
+
 		$queues = $this->queues();
 		if(!is_array($queues)) {
 			return;


### PR DESCRIPTION
Specifically, this improves the multi-worker forking process by having the
parent process stick around and monitor the children.  If a child process
dies, and the supervisor has not been instructed to shut them all down, it
will spawn a new child to replace it.  It will pass signals down to all
children.  Currently, it only passes the signals explicitly watched by the
Worker class.  Children will be told that they have a parent process, and
check periodically whether the supervisor is still running.  This check is
performed at the beginning of reserve() to ensure orphaned workers handle
their condition properly.  That is, if the supervisor is gone, the child will
exit.  This is intended to allow users to kill the supervisor and
realistically expect that no new jobs will be processed until a new
supervisor (or single-worker instance) is started.

The other change, not related to worker-supervisor relationships,
nevertheless still involves forking.  Specifically, when a job process exits,
the exit code is already being handled if it is greater than zero.  However,
if it is zero, the code prior to this commit assumed the exit was performed
by PHP Resque itself.  Usually, this is correct.  The trouble comes when jobs
exit without specifying an exit status - PHP defaults these to 0, for
whatever reason.  In these cases, the job status is not properly updated.
Generally speaking, if you're writing jobs yourself - in their entirety -
they will responsibly _not_ use exit() at any point.  But if your jobs use a
framework, the chances of an unexpected exit() causing issues go up immensely.
So, if the exit code is zero, and the job status hasn't been updated from
queued or running, this commit's code causes the status to be updated to
completed.  This assumes that such jobs are properly written to only use exit
status 0 for success, so some users might wish to change it to failed, but
that's not best practice in the slightest, so I wouldn't encourage that.

Signed-off-by: Daniel Hunsaker danhunsaker@gmail.com
