### PR TITLE
REDIS_BACKEND_DB env variable added

### DIFF
--- a/bin/resque
+++ b/bin/resque
@@ -30,8 +30,12 @@ if(empty($QUEUE)) {
 }
 
 $REDIS_BACKEND = getenv('REDIS_BACKEND');
+$REDIS_BACKEND_DB = getenv('REDIS_BACKEND_DB');
 if(!empty($REDIS_BACKEND)) {
-	Resque::setBackend($REDIS_BACKEND);
+	if (empty($REDIS_BACKEND_DB)) 
+		Resque::setBackend($REDIS_BACKEND);
+	else
+		Resque::setBackend($REDIS_BACKEND, $REDIS_BACKEND_DB);
 }
 
 $logLevel = 0;


### PR DESCRIPTION
It's enable the possibility of use a different db index on redis backend
