### PR TITLE
Adding support for remote redis instances (such as redistogo) that require authentication

### DIFF
--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -101,6 +101,7 @@ class Resque_Redis
 		}
 		else {
 			$port = null;
+			$password = null;
 			$host = $server;
 
 			// If not a UNIX socket path or tcp:// formatted connections string
@@ -111,8 +112,19 @@ class Resque_Redis
 					$port = $parts[1];
 				}
 				$host = $parts[0];
+			}else if (strpos($server, 'redis://') !== false){
+				// Redis format is:
+				// redis://[user]:[password]@[host]:[port]
+				list($userpwd,$hostport) = explode('@', $server);
+				$userpwd = substr($userpwd, strpos($userpwd, 'redis://')+8);
+				list($host, $port) = explode(':', $hostport);
+				list($user, $password) = explode(':', $userpwd);
 			}
+			
 			$this->driver = new Credis_Client($host, $port);
+			if (isset($password)){
+				$this->driver->auth($password);
+			}
 		}
 
 		if ($this->database !== null) {


### PR DESCRIPTION
Simple password authentication when using the redis:// syntax that provide a password (and optionally username, though username is ignored).
