### PR TITLE
Bugfix: workers on non-forking OSs read jobs from the queue, but never actually do any work on them.

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -187,7 +187,7 @@ class Resque_Worker
 			$this->child = Resque::fork();
 
 			// Forked and we're the child. Run the job.
-			if ($this->child === 0 || $this->child === false) {
+			if ($this->child === 0 || $this->child === false || $this->child === -1) {
 				$status = 'Processing ' . $job->queue . ' since ' . strftime('%F %T');
 				$this->updateProcLine($status);
 				$this->log($status, self::LOG_VERBOSE);


### PR DESCRIPTION
Change from $this->fork() to Resque::fork() in 6800fbe5ac8000c617f53c94a3621b74908f52e7 now returns -1 (not false) and this should be checked for.