### PR TITLE
Check for installed pcntl extension via composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 	],
 	"require": {
 		"php": ">=5.3.0",
+		"ext-pcntl": "*",
 		"colinmollenhour/credis": "dev-master"
 	},
 	"suggest": {


### PR DESCRIPTION
Hi, 

This issue is related to https://github.com/chrisboulton/php-resque/issues/98 , https://github.com/chrisboulton/php-resque/pull/93 , https://github.com/chrisboulton/php-resque/pull/94

This is not a fix Rather a update on composer to tell the user that he would need php extension PCNTL. 
