### PR TITLE
Fixed $args in the Job::recreate method

### DIFF
--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -226,7 +226,7 @@ class Resque_Job
 			$monitor = true;
 		}
 
-		return self::create($this->queue, $this->payload['class'], $this->payload['args'], $monitor);
+		return self::create($this->queue, $this->payload['class'], $this->getArguments(), $monitor);
 	}
 
 	/**


### PR DESCRIPTION
Previous code was encapsulating $args in an additional array, and thus breaking the new job $args.
