### PR TITLE
Added enqueue failure detection

### DIFF
--- a/lib/Resque.php
+++ b/lib/Resque.php
@@ -98,11 +98,11 @@ class Resque
 	public static function push($queue, $item)
 	{
 		self::redis()->sadd('queues', $queue);
-		if (self::redis()->rpush('queue:' . $queue, json_encode($item)) < 1)
-		{
-			return FALSE;
+		$length = self::redis()->rpush('queue:' . $queue, json_encode($item));
+		if ($length < 1) {
+			return false;
 		}
-		return TRUE;
+		return true;
 	}
 
 	/**

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -58,13 +58,12 @@ class Resque_Job
 			);
 		}
 		$id = md5(uniqid('', true));
-		if ( ! Resque::push($queue, array(
+		if (!Resque::push($queue, array(
 			'class'	=> $class,
 			'args'	=> array($args),
 			'id'	=> $id,
-		)))
-		{
-			return FALSE;
+		))) {
+			return false;
 		}
 
 		if($monitor) {


### PR DESCRIPTION
If a job fails to be enqueued, it would be useful to know it.  So now
Resque actually tells us whether the enqueue action was successful or
if it failed.  If your job ID comes back as FALSE, it didn't enqueue.

Signed-off-by: Daniel Hunsaker danhunsaker@gmail.com
