### PR TITLE
make workers more robust by not including 3rd party code before forking

### DIFF
--- a/bin/resque
+++ b/bin/resque
@@ -56,7 +56,7 @@ if($APP_INCLUDE) {
 		die('APP_INCLUDE ('.$APP_INCLUDE.") does not exist.\n");
 	}
 
-	require_once $APP_INCLUDE;
+	Resque_Job::$appInclude = $APP_INCLUDE;
 }
 
 $interval = 5;

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -29,6 +29,11 @@ class Resque_Job
 	private $instance;
 
 	/**
+	 * @var string location of autoloader
+	 */
+	public static $appInclude;
+
+	/**
 	 * Instantiate a new instance of a job.
 	 *
 	 * @param string $queue The queue that the job belongs to.
@@ -138,6 +143,9 @@ class Resque_Job
 		if (!is_null($this->instance)) {
 			return $this->instance;
 		}
+
+		// latest point to require appInclude
+		require_once self::$appInclude;
 
 		if(!class_exists($this->payload['class'])) {
 			throw new Resque_Exception(

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -53,6 +53,9 @@ class Resque_Worker
 	 */
 	private $child = null;
 
+	/** @var string  location of the autoloader used for Job creation */
+	private $workerAutoloader;
+
 	/**
 	 * Return all workers known to Resque as instantiated instances.
 	 * @return array


### PR DESCRIPTION
Hi Chris,

I had the problem with failing workers due to some errors within foreign autoloader code.
This changeset only includes the code at the point where a worker already has been forker.

Therefor only the job will fail - not the worker itself

Cheers
B
