### PR TITLE
Fix notice for: 'Undefined variable: logger'

### DIFF
--- a/bin/resque
+++ b/bin/resque
@@ -61,7 +61,7 @@ if($APP_INCLUDE) {
 
 // See if the APP_INCLUDE containes a logger object,
 // If none exists, fallback to internal logger
-if (!isset($logger) && !is_object($logger)) {
+if (!isset($logger) || !is_object($logger)) {
     $logger = new Resque_Log($logLevel);
 }
 


### PR DESCRIPTION
After last update, got this notice:

PHP Notice:  Undefined variable: logger in vendor/chrisboulton/php-resque/bin/resque on line 64
PHP Stack trace:
PHP   1. {main}() vendor/chrisboulton/php-resque/bin/resque:0

Notice: Undefined variable: logger in vendor/chrisboulton/php-resque/bin/resque on line 64

Call Stack:
    0.0003     246720   1. {main}() vendor/chrisboulton/php-resque/bin/resque:0
