### PR TITLE
Resque/Worker: removed reestablishConnection

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -350,7 +350,6 @@ class Resque_Worker
 		pcntl_signal(SIGUSR1, array($this, 'killChild'));
 		pcntl_signal(SIGUSR2, array($this, 'pauseProcessing'));
 		pcntl_signal(SIGCONT, array($this, 'unPauseProcessing'));
-		pcntl_signal(SIGPIPE, array($this, 'reestablishRedisConnection'));
 		$this->logger->log(Psr\Log\LogLevel::DEBUG, 'Registered signals');
 	}
 
@@ -371,16 +370,6 @@ class Resque_Worker
 	{
 		$this->logger->log(Psr\Log\LogLevel::NOTICE, 'CONT received; resuming job processing');
 		$this->paused = false;
-	}
-
-	/**
-	 * Signal handler for SIGPIPE, in the event the redis connection has gone away.
-	 * Attempts to reconnect to redis, or raises an Exception.
-	 */
-	public function reestablishRedisConnection()
-	{
-		$this->logger->log(Psr\Log\LogLevel::NOTICE, 'SIGPIPE received; attempting to reconnect');
-		Resque::redis()->establishConnection();
 	}
 
 	/**


### PR DESCRIPTION
Both CRedis and PHPRedis support automatic reconnection. There is no use of catching SIGPIPE signal. But php-resque now calls method establishConnection that was only in redisent client library.

https://github.com/chrisboulton/php-resque/issues/110
