### PR TITLE
Let Resque_Worker::updateProcLine() use PHP 5.5's cli_set_process_title() if available

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -324,7 +324,10 @@ class Resque_Worker
 	 */
 	private function updateProcLine($status)
 	{
-		if(function_exists('setproctitle')) {
+		if(function_exists('cli_set_process_title')) {
+			cli_set_process_title('resque-' . Resque::VERSION . ': ' . $status);
+		}
+		else if(function_exists('setproctitle')) {
 			setproctitle('resque-' . Resque::VERSION . ': ' . $status);
 		}
 	}

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -324,11 +324,12 @@ class Resque_Worker
 	 */
 	private function updateProcLine($status)
 	{
+        $processTitle = 'resque-' . Resque::VERSION . ': ' . $status;
 		if(function_exists('cli_set_process_title')) {
-			cli_set_process_title('resque-' . Resque::VERSION . ': ' . $status);
+			cli_set_process_title($processTitle);
 		}
 		else if(function_exists('setproctitle')) {
-			setproctitle('resque-' . Resque::VERSION . ': ' . $status);
+			setproctitle($processTitle);
 		}
 	}
 

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -324,7 +324,7 @@ class Resque_Worker
 	 */
 	private function updateProcLine($status)
 	{
-        $processTitle = 'resque-' . Resque::VERSION . ': ' . $status;
+		$processTitle = 'resque-' . Resque::VERSION . ': ' . $status;
 		if(function_exists('cli_set_process_title')) {
 			cli_set_process_title($processTitle);
 		}


### PR DESCRIPTION
updateProcLine() uses the PECL function setproctitle() if available. It should also try to use cli_set_process_title(), available in PHP 5.5.

cli_set_process_title() is preferred because setproctitle() is "incomplete and might lead to memory corruption on Linux". (See https://wiki.php.net/rfc/cli_process_title )
