### PR TITLE
Keeping track of Process status as well as result

### DIFF
--- a/lib/Resque.php
+++ b/lib/Resque.php
@@ -181,9 +181,9 @@ class Resque
 	 *
 	 * @return string
 	 */
-	public static function enqueue($queue, $class, $args = null, $trackStatus = false)
+	public static function enqueue($queue, $class, $args = null, $trackStatus = false, $prefix = "")
 	{
-		$result = Resque_Job::create($queue, $class, $args, $trackStatus);
+		$result = Resque_Job::create($queue, $class, $args, $trackStatus, $prefix);
 		if ($result) {
 			Resque_Event::trigger('afterEnqueue', array(
 				'class' => $class,

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -236,9 +236,10 @@ class Resque_Worker
 	 */
 	public function perform(Resque_Job $job)
 	{
+        $result = "";
 		try {
 			Resque_Event::trigger('afterFork', $job);
-			$job->perform();
+			$result = $job->perform();
 		}
 		catch(Exception $e) {
 			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => $e->getMessage()));
@@ -246,7 +247,7 @@ class Resque_Worker
 			return;
 		}
 
-		$job->updateStatus(Resque_Job_Status::STATUS_COMPLETE);
+		$job->updateStatus(Resque_Job_Status::STATUS_COMPLETE, $result);
 		$this->logger->log(Psr\Log\LogLevel::NOTICE, '{job} has finished', array('job' => $job));
 	}
 


### PR DESCRIPTION
- if the "Perform()" function returns result, store it along with process status
- return process status+result in Resque_Job_Status->get()
- allow user to delete the status from redis

Prefix while enqueuing
- to add one more level of saperation, (e.g. If you have a class between application and resque, the class can handle this, so a prefix can be userid or something in background, so one user do not access another user's queue status items)
