### PR TITLE
Keeping track of Process status as well as result and allow user to add prefix for their job

### DIFF
--- a/lib/Resque.php
+++ b/lib/Resque.php
@@ -181,9 +181,9 @@ class Resque
 	 *
 	 * @return string
 	 */
-	public static function enqueue($queue, $class, $args = null, $trackStatus = false, $prefix = "")
+	public static function enqueue($queue, $class, $args = null, $trackStatus = false)
 	{
-		$result = Resque_Job::create($queue, $class, $args, $trackStatus, $prefix);
+		$result = Resque_Job::create($queue, $class, $args, $trackStatus);
 		if ($result) {
 			Resque_Event::trigger('afterEnqueue', array(
 				'class' => $class,

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -47,11 +47,10 @@ class Resque_Job
 	 * @param string $class The name of the class that contains the code to execute the job.
 	 * @param array $args Any optional arguments that should be passed when the job is executed.
 	 * @param boolean $monitor Set to true to be able to monitor the status of a job.
-	 * @param string $prefix The prefix needs to be set for the status key
 	 *
 	 * @return string
 	 */
-	public static function create($queue, $class, $args = null, $monitor = false, $prefix = "")
+	public static function create($queue, $class, $args = null, $monitor = false)
 	{
 		if($args !== null && !is_array($args)) {
 			throw new InvalidArgumentException(
@@ -63,11 +62,10 @@ class Resque_Job
 			'class'	=> $class,
 			'args'	=> array($args),
 			'id'	=> $id,
-			'prefix' => $prefix
 		));
 
 		if($monitor) {
-			Resque_Job_Status::create($id, $prefix);
+			Resque_Job_Status::create($id);
 		}
 
 		return $id;
@@ -120,7 +118,7 @@ class Resque_Job
 			return;
 		}
 
-		$statusInstance = new Resque_Job_Status($this->payload['id'], $this->payload['prefix']);
+		$statusInstance = new Resque_Job_Status($this->payload['id']);
 		$statusInstance->update($status, $result);
 	}
 
@@ -131,7 +129,7 @@ class Resque_Job
 	 */
 	public function getStatus()
 	{
-		$status = new Resque_Job_Status($this->payload['id'], $this->payload['prefix']);
+		$status = new Resque_Job_Status($this->payload['id']);
 		return $status->get();
 	}
 
@@ -242,7 +240,7 @@ class Resque_Job
 	 */
 	public function recreate()
 	{
-		$status = new Resque_Job_Status($this->payload['id'], $this->payload['prefix']);
+		$status = new Resque_Job_Status($this->payload['id']);
 		$monitor = false;
 		if($status->isTracking()) {
 			$monitor = true;

--- a/lib/Resque/Job/Status.php
+++ b/lib/Resque/Job/Status.php
@@ -14,11 +14,6 @@ class Resque_Job_Status
 	const STATUS_COMPLETE = 4;
 
 	/**
-	 * @var string The prefix of the job status id.
-	 */
-	private $prefix;
-    
-	/**
 	 * @var string The ID of the job this status class refers back to.
 	 */
 	private $id;
@@ -42,10 +37,9 @@ class Resque_Job_Status
 	 *
 	 * @param string $id The ID of the job to manage the status for.
 	 */
-	public function __construct($id, $prefix = "")
+	public function __construct($id)
 	{
 		$this->id = $id;
-		$this->prefix = $prefix;
 	}
 
 	/**
@@ -54,14 +48,14 @@ class Resque_Job_Status
 	 *
 	 * @param string $id The ID of the job to monitor the status of.
 	 */
-	public static function create($id, $prefix = "")
+	public static function create($id)
 	{
 		$statusPacket = array(
 			'status' => self::STATUS_WAITING,
 			'updated' => time(),
 			'started' => time(),
 		);
-		Resque::redis()->set('job:' . $prefix . $id . ':status', json_encode($statusPacket));
+		Resque::redis()->set('job:' . $id . ':status', json_encode($statusPacket));
 	}
 
 	/**
@@ -178,7 +172,7 @@ class Resque_Job_Status
 	 */
 	public function __toString()
 	{
-		return 'job:' . $this->prefix . $this->id . ':status';
+		return 'job:' . $this->id . ':status';
 	}
 }
 ?>


### PR DESCRIPTION
**Keeping track of Process status as well as result**
- if the "Perform()" function returns result, store it along with process status
- return process status+result in Resque_Job_Status->get()
- allow user to delete the status from redis
- allow user to query result of the job

**Prefix while enqueuing**

to add one more level of saperation, (e.g. If you have a class between application and resque, the class can handle this, so a prefix can be userid or something in background, so one user do not access another user's queue status items)
