### PR TITLE
Keeping track of Process status as well as result

### DIFF
--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -112,14 +112,14 @@ class Resque_Job
 	 *
 	 * @param int $status Status constant from Resque_Job_Status indicating the current status of a job.
 	 */
-	public function updateStatus($status)
+	public function updateStatus($status, $result = "")
 	{
 		if(empty($this->payload['id'])) {
 			return;
 		}
 
 		$statusInstance = new Resque_Job_Status($this->payload['id']);
-		$statusInstance->update($status);
+		$statusInstance->update($status, $result);
 	}
 
 	/**
@@ -186,6 +186,7 @@ class Resque_Job
 	 */
 	public function perform()
 	{
+		$result = true;
 		$instance = $this->getInstance();
 		try {
 			Resque_Event::trigger('beforePerform', $this);
@@ -194,7 +195,7 @@ class Resque_Job
 				$instance->setUp();
 			}
 
-			$instance->perform();
+			$result = $instance->perform();
 
 			if(method_exists($instance, 'tearDown')) {
 				$instance->tearDown();
@@ -207,7 +208,7 @@ class Resque_Job
 			return false;
 		}
 
-		return true;
+		return $result;
 	}
 
 	/**

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -236,9 +236,10 @@ class Resque_Worker
 	 */
 	public function perform(Resque_Job $job)
 	{
+		$result = "";
 		try {
 			Resque_Event::trigger('afterFork', $job);
-			$job->perform();
+			$result = $job->perform();
 		}
 		catch(Exception $e) {
 			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => $e->getMessage()));
@@ -246,7 +247,7 @@ class Resque_Worker
 			return;
 		}
 
-		$job->updateStatus(Resque_Job_Status::STATUS_COMPLETE);
+		$job->updateStatus(Resque_Job_Status::STATUS_COMPLETE, $result);
 		$this->logger->log(Psr\Log\LogLevel::NOTICE, '{job} has finished', array('job' => $job));
 	}
 


### PR DESCRIPTION
- if the "Perform()" function returns result, store it along with process status
- return process status+result in Resque_Job_Status->get()
- allow user to delete the status from redis
- allow user to query result of the job
