### PR TITLE
Prefix while enqueuing

### DIFF
--- a/lib/Resque.php
+++ b/lib/Resque.php
@@ -181,9 +181,9 @@ class Resque
 	 *
 	 * @return string
 	 */
-	public static function enqueue($queue, $class, $args = null, $trackStatus = false)
+	public static function enqueue($queue, $class, $args = null, $trackStatus = false, $prefix = "")
 	{
-		$result = Resque_Job::create($queue, $class, $args, $trackStatus);
+		$result = Resque_Job::create($queue, $class, $args, $trackStatus, $prefix);
 		if ($result) {
 			Resque_Event::trigger('afterEnqueue', array(
 				'class' => $class,

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -47,10 +47,11 @@ class Resque_Job
 	 * @param string $class The name of the class that contains the code to execute the job.
 	 * @param array $args Any optional arguments that should be passed when the job is executed.
 	 * @param boolean $monitor Set to true to be able to monitor the status of a job.
+	 * @param string $prefix The prefix needs to be set for the status key
 	 *
 	 * @return string
 	 */
-	public static function create($queue, $class, $args = null, $monitor = false)
+	public static function create($queue, $class, $args = null, $monitor = false, $prefix = "")
 	{
 		if($args !== null && !is_array($args)) {
 			throw new InvalidArgumentException(
@@ -62,10 +63,11 @@ class Resque_Job
 			'class'	=> $class,
 			'args'	=> array($args),
 			'id'	=> $id,
+			'prefix' => $prefix
 		));
 
 		if($monitor) {
-			Resque_Job_Status::create($id);
+			Resque_Job_Status::create($id, $prefix);
 		}
 
 		return $id;
@@ -118,7 +120,7 @@ class Resque_Job
 			return;
 		}
 
-		$statusInstance = new Resque_Job_Status($this->payload['id']);
+		$statusInstance = new Resque_Job_Status($this->payload['id'], $this->payload['prefix']);
 		$statusInstance->update($status);
 	}
 
@@ -129,7 +131,7 @@ class Resque_Job
 	 */
 	public function getStatus()
 	{
-		$status = new Resque_Job_Status($this->payload['id']);
+		$status = new Resque_Job_Status($this->payload['id'], $this->payload['prefix']);
 		return $status->get();
 	}
 
@@ -239,7 +241,7 @@ class Resque_Job
 	 */
 	public function recreate()
 	{
-		$status = new Resque_Job_Status($this->payload['id']);
+		$status = new Resque_Job_Status($this->payload['id'], $this->payload['prefix']);
 		$monitor = false;
 		if($status->isTracking()) {
 			$monitor = true;

--- a/lib/Resque/Job/Status.php
+++ b/lib/Resque/Job/Status.php
@@ -14,6 +14,11 @@ class Resque_Job_Status
 	const STATUS_COMPLETE = 4;
 
 	/**
+	 * @var string The prefix of the job status id.
+	 */
+	private $prefix;
+    
+	/**
 	 * @var string The ID of the job this status class refers back to.
 	 */
 	private $id;
@@ -37,9 +42,10 @@ class Resque_Job_Status
 	 *
 	 * @param string $id The ID of the job to manage the status for.
 	 */
-	public function __construct($id)
+	public function __construct($id, $prefix = "")
 	{
 		$this->id = $id;
+		$this->prefix = $prefix;
 	}
 
 	/**
@@ -48,14 +54,14 @@ class Resque_Job_Status
 	 *
 	 * @param string $id The ID of the job to monitor the status of.
 	 */
-	public static function create($id)
+	public static function create($id, $prefix = "")
 	{
 		$statusPacket = array(
 			'status' => self::STATUS_WAITING,
 			'updated' => time(),
 			'started' => time(),
 		);
-		Resque::redis()->set('job:' . $id . ':status', json_encode($statusPacket));
+		Resque::redis()->set('job:' . $prefix . $id . ':status', json_encode($statusPacket));
 	}
 
 	/**
@@ -137,7 +143,7 @@ class Resque_Job_Status
 	 */
 	public function __toString()
 	{
-		return 'job:' . $this->id . ':status';
+		return 'job:' . $this->prefix . $this->id . ':status';
 	}
 }
 ?>


### PR DESCRIPTION
to add one more level of saperation, (e.g. If you have a class between application and resque, the class can handle this, so a prefix can be userid or something in background, so one user do not access another user's queue status items)
