### PR TITLE
Properly get workers pids when running on SunOS.

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -452,10 +452,15 @@ class Resque_Worker
 	public function workerPids()
 	{
 		$pids = array();
-		exec('ps -A -o pid,command | grep [r]esque', $cmdOutput);
-		foreach($cmdOutput as $line) {
+		if (PHP_OS === "SunOS") {
+			exec('ps -A -o pid,comm,args | grep [r]esque', $cmdOutput);
+		} else {
+			exec('ps -A -o pid,command | grep [r]esque', $cmdOutput);
+		}
+		foreach ($cmdOutput as $line) {
 			list($pids[],) = explode(' ', trim($line), 2);
 		}
+
 		return $pids;
 	}
 


### PR DESCRIPTION
When getting worker pids on SunOS (OpenIndiana or any other Solaris derivative) the ps command does not support the arguments as on linux. So to be able to get the worker pids the command line arguments for ps need to be changed. 
