### PR TITLE
Remove unused credis repo from composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,6 @@
 			"email": "chris@bigcommerce.com"
 		}
 	],
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/chrisboulton/credis"
-		}
-	],
 	"require": {
 		"php": ">=5.3.0",
 		"ext-pcntl": "*",


### PR DESCRIPTION
The credis vcs in the composer.json file isn't actually used, the version in packagist is used instead, so I've removed it.
