### PR TITLE
Added token as an argument to the afterEnqueue callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ Called after a job has been queued using the `Resque::enqueue` method. Arguments
 * Class - string containing the name of scheduled job
 * Arguments - array of arguments supplied to the job
 * Queue - string containing the name of the queue the job was added to
-* Token - string containing the new token of the enqueued job
+* Id - string containing the new token of the enqueued job
 
 ## Contributors ##
 

--- a/lib/Resque.php
+++ b/lib/Resque.php
@@ -189,7 +189,7 @@ class Resque
 				'class' => $class,
 				'args'  => $args,
 				'queue' => $queue,
-				'token' => $result,
+				'id'    => $result,
 			));
 		}
 


### PR DESCRIPTION
We've been using php-resque and it's fantastic, thanks for the great work!

We've been tracking the status of some of our jobs outside of php-resque, but we weren't able to get a useful identifier from inside the afterEnqueue event callback.  This pull request adds the newly created token as the fourth argument to the callback, and updates the readme accordingly.
