### PR TITLE
Fixes the examples for using VERBOSE and VVERBOSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ Setting `VERBOSE` will print basic debugging information and `VVERBOSE`
 will print detailed information.
 
 ```sh
-$ VERBOSE QUEUE=file_serve bin/resque
-$ VVERBOSE QUEUE=file_serve bin/resque
+$ VERBOSE=1 QUEUE=file_serve bin/resque
+$ VVERBOSE=1 QUEUE=file_serve bin/resque
 ```
 
 ### Priorities and Queue Lists ###


### PR DESCRIPTION
The example for the VERBOSE and VVERBOSE options would throw a 'command not found' error when attempting to use it in the same manner as it was originally documented.
