### PR TITLE
Fixing issue with ambiguous dsn

### DIFF
--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -113,7 +113,7 @@ class Resque_Redis
 					$port = $parts[1];
 				}
 				$host = $parts[0];
-			}else if (strpos($server, 'redis://') !== false){
+			}else if (strpos($server, 'redis://') !== false && strpos($server, '@') !== false){
 				// Redis format is:
 				// redis://[user]:[password]@[host]:[port]
 				list($userpwd,$hostport) = explode('@', $server);

--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -113,13 +113,18 @@ class Resque_Redis
 					$port = $parts[1];
 				}
 				$host = $parts[0];
-			}else if (strpos($server, 'redis://') !== false && strpos($server, '@') !== false){
+			}else if (strpos($server, 'redis://') !== false){
 				// Redis format is:
 				// redis://[user]:[password]@[host]:[port]
-				list($userpwd,$hostport) = explode('@', $server);
-				$userpwd = substr($userpwd, strpos($userpwd, 'redis://')+8);
+                if(strpos($server, '@') !== false){
+				    list($userpwd,$hostport) = explode('@', $server);
+                    $userpwd = substr($userpwd, strpos($userpwd, 'redis://')+8);
+                    list($user, $password) = explode(':', $userpwd);
+                }else{
+                    $hostport = substr($server, strpos($server, 'redis://')+8);
+                }
 				list($host, $port) = explode(':', $hostport);
-				list($user, $password) = explode(':', $userpwd);
+
 			}
 			
 			$this->driver = new Credis_Client($host, $port);


### PR DESCRIPTION
I have a cloud provider that injects the DSN into the environment. This dsn sometimes looks like "redis://localhost:6379", which would throw an exception on explode('@', $server), thats why I added the additional check.