### PR TITLE
Worker pcntl_wait to non-blocking loop

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -215,6 +215,9 @@ class Resque_Worker
 				// Wait until the child process finishes before continuing
 				while(pcntl_wait($status, WNOHANG) === 0) {
 					pcntl_signal_dispatch();
+
+					// Pause for a half a second to conserve system resources
+					usleep(500000);
 				}
 				$exitStatus = pcntl_wexitstatus($status);
 				if($exitStatus !== 0) {


### PR DESCRIPTION
Putting the thread to sleep with `pcntl_wait` no longer allows signals to be captured (PHP 5 >= 5.3.0). This PR puts `pcntl_wait` into a while loop waiting for the child to exit, and allows signals like USR1 to be used again (`pcntl_signal_dispatch` being called inside the loop).

My only concern would be compatibility with PHP< 5.3.0

http://www.php.net/manual/en/function.pcntl-signal.php#114575
http://www.php.net/manual/en/function.pcntl-signal-dispatch.php
