### PR TITLE
Include message and backtrace from previous exceptions.

### DIFF
--- a/lib/Resque/Failure/Redis.php
+++ b/lib/Resque/Failure/Redis.php
@@ -23,12 +23,54 @@ class Resque_Failure_Redis implements Resque_Failure_Interface
 		$data->failed_at = strftime('%a %b %d %H:%M:%S %Z %Y');
 		$data->payload = $payload;
 		$data->exception = get_class($exception);
-		$data->error = $exception->getMessage();
-		$data->backtrace = explode("\n", $exception->getTraceAsString());
+		$data->error = $this->formatExceptionMessage($exception);
+		$data->backtrace = $this->formatExceptionTrace($exception);
 		$data->worker = (string)$worker;
 		$data->queue = $queue;
 		$data = json_encode($data);
 		Resque::redis()->rpush('failed', $data);
+	}
+
+	/**
+	 * Get the exception message with code, if available.
+	 *
+	 * @param object $exception
+	 *
+	 * @return string
+	 */
+	private function formatExceptionMessage($exception)
+	{
+		$message = $exception->getMessage();
+
+		$code = $exception->getCode();
+		if ($code) {
+			// getCode(..) returns the exception code as integer in Exception,
+			// but possibly as other type in descendants, assume string.
+			$message = sprintf('[%s] %s', $code, $message);
+		}
+
+		return $message;
+	}
+
+	/**
+	 * Get a detailed exception trace including and previous exceptions.
+	 *
+	 * @param object $exception
+	 *
+	 * @return string[]
+	 */
+	private function formatExceptionTrace($exception)
+	{
+		$trace = explode("\n", $exception->getTraceAsString());
+
+		$previous = $exception->getPrevious();
+		if ($previous instanceof \Exception) {
+			$trace[] = null;
+			$trace[] = sprintf('Caused by: %s', $this->formatExceptionMessage($previous));
+			$trace = array_merge($trace, $this->formatExceptionTrace($previous));
+		}
+
+		return $trace;
 	}
 }
 ?>


### PR DESCRIPTION
If an exception wraps another, it is impossible to tell what the cause was looking at the outer exception only. If this pull request is merged, when a job fails the full backtrace of all previous exceptions is recorded.

Before:

```
Cannot create User.
#0 file.php(1): createUser
```

After:

```
Cannot create User.
#0 file.php(1): createUser

Caused by: Cannot connect to database.
#0 db.php(1): connect
```
