### PR TITLE
Die immediately on redis error.

### DIFF
--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -151,12 +151,7 @@ class Resque_Redis
                 $args[0] = self::$defaultNamespace . $args[0];
             }
 		}
-		try {
-			return $this->driver->__call($name, $args);
-		}
-		catch(CredisException $e) {
-			return false;
-		}
+        return $this->driver->__call($name, $args);
 	}
 
     public static function getPrefix()


### PR DESCRIPTION
Credis can't reconnect to redis after one failure.

 - It is better to kill the worker and restart it.
 - The exception should not be converted to false because false (or empty array) is returned when there is no job in redis too.

#179