### PR TITLE
More verbose logging if a Job throws an exception

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -241,7 +241,7 @@ class Resque_Worker
 			$job->perform();
 		}
 		catch(Exception $e) {
-			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => (string)$e));
+			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => $e));
 			$job->fail($e);
 			return;
 		}

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -241,7 +241,7 @@ class Resque_Worker
 			$job->perform();
 		}
 		catch(Exception $e) {
-			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => (string)$e);
+			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => (string)$e));
 			$job->fail($e);
 			return;
 		}

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -241,7 +241,7 @@ class Resque_Worker
 			$job->perform();
 		}
 		catch(Exception $e) {
-			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => $e->getMessage()));
+g			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => (string)$e);
 			$job->fail($e);
 			return;
 		}

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -241,7 +241,7 @@ class Resque_Worker
 			$job->perform();
 		}
 		catch(Exception $e) {
-g			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => (string)$e);
+			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => (string)$e);
 			$job->fail($e);
 			return;
 		}


### PR DESCRIPTION
Presently, the logger just logs the primary error message with no stack trace of additional debugging information. Type casting the exception to a string gives a much efficient output  and enables better debugging.