### PR TITLE
Make the credis requirements less strict.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 	"require": {
 		"php": ">=5.3.0",
 		"ext-pcntl": "*",
-		"colinmollenhour/credis": "1.2.*",
+		"colinmollenhour/credis": "~1.2",
 		"psr/log": "1.0.0"
 	},
 	"suggest": {


### PR DESCRIPTION
Since credis has moved forward, but is backwards compatible, resque shouldn’t
be so strict towards an old version because other libraries need newer credis
features.

This seems like a nit-pick I know, but I need to use a more recent version of
credis and also use php-resque, but am getting dependency errors.
