### PR TITLE
Adding beforeEnqueue event on Resque enqueue.

### DIFF
--- a/lib/Resque.php
+++ b/lib/Resque.php
@@ -181,7 +181,7 @@ class Resque
 		$beforeEnqueue = true;
 		$beforeEnqueue = Resque_Event::trigger('beforeEnqueue', array(
 			'class' => $class,
-			'args' => $args,
+			'args' => &$args,
 			'queue' => $queue
 		));
 

--- a/lib/Resque/Event.php
+++ b/lib/Resque/Event.php
@@ -34,7 +34,8 @@ class Resque_Event
 			if (!is_callable($callback)) {
 				continue;
 			}
-			call_user_func_array($callback, $data);
+			$return = call_user_func_array($callback, $data);
+			return $return;
 		}
 		
 		return true;


### PR DESCRIPTION
This so that we can stop jobs from queuing up via Event Hooks, so that we can do something like this to create a unique queue:

```php
class ResqueUniquePlugin {
  public function beforeEnqueue($class, array $arguments, $queue) {
    if (Resque::redis()->exists($arguments['unique_key'])) {
      return FALSE;
    }
    Resque::redis()->set($arguments['unique_key'], '1');
    return TRUE;
  }

  public function afterPerform(Resque_Job $job) {
    if (Resque::redis()->exists($job->payload['args'][0]['unique_key'])) {
      Resque::redis()->del($job->payload['args'][0]['unique_key']);
    }
  }

  public function onFailure($exception, Resque_Job $job) {
    if (Resque::redis()->exists($job->payload['args'][0]['unique_key'])) {
      Resque::redis()->del($job->payload['args'][0]['unique_key']);
    }
  }
}
```