### PR TITLE
add an enqueued timestamp to the job payload

### DIFF
--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -62,6 +62,7 @@ class Resque_Job
 			'class'	=> $class,
 			'args'	=> array($args),
 			'id'	=> $id,
+			'queue_time' => microtime(true),
 		));
 
 		if($monitor) {


### PR DESCRIPTION
This adds the `qtime` to the job payload so that we can track job queueing time in statsd.
