### PR TITLE
Remove the matched item from the $tempQueue list.

### DIFF
--- a/lib/Resque.php
+++ b/lib/Resque.php
@@ -265,6 +265,7 @@ class Resque
 
 		if(!empty($string)) {
 		    if(self::matchItem($string, $items)) {
+		    	self::redis()->rpop($tempQueue);
 			$counter++;
 		    } else {
 			self::redis()->rpoplpush($tempQueue, self::redis()->getPrefix() . $requeueQueue);


### PR DESCRIPTION
Removes the matched item from the list to properly dequeue a job. Addresses issue #218.