### PR TITLE
Surface Redis exceptions instead of silently returning false

### DIFF
--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -142,7 +142,7 @@ class Resque_Redis
 			}
 		}
 		catch(CredisException $e) {
-			throw new Resque_RedisException($e);
+			throw new Resque_RedisException('Error communicating with Redis: ' . $e->getMessage(), 0, $e);
 		}
 	}
 
@@ -245,7 +245,7 @@ class Resque_Redis
 			return $this->driver->__call($name, $args);
 		}
 		catch (CredisException $e) {
-			throw new Resque_RedisException($e);
+			throw new Resque_RedisException('Error communicating with Redis: ' . $e->getMessage(), 0, $e);
 		}
 	}
 

--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -111,34 +111,38 @@ class Resque_Redis
 	 */
     public function __construct($server, $database = null)
 	{
-		if (is_array($server)) {
-			$this->driver = new Credis_Cluster($server);
-		}
-		else {
+		try {
+			if (is_array($server)) {
+				$this->driver = new Credis_Cluster($server);
+			}
+			else {
+				list($host, $port, $dsnDatabase, $user, $password, $options) = self::parseDsn($server);
+				// $user is not used, only $password
 
-			list($host, $port, $dsnDatabase, $user, $password, $options) = self::parseDsn($server);
-			// $user is not used, only $password
+				// Look for known Credis_Client options
+				$timeout = isset($options['timeout']) ? intval($options['timeout']) : null;
+				$persistent = isset($options['persistent']) ? $options['persistent'] : '';
+				$maxRetries = isset($options['max_connect_retries']) ? $options['max_connect_retries'] : 0;
 
-			// Look for known Credis_Client options
-			$timeout = isset($options['timeout']) ? intval($options['timeout']) : null;
-			$persistent = isset($options['persistent']) ? $options['persistent'] : '';
-			$maxRetries = isset($options['max_connect_retries']) ? $options['max_connect_retries'] : 0;
+				$this->driver = new Credis_Client($host, $port, $timeout, $persistent);
+				$this->driver->setMaxConnectRetries($maxRetries);
+				if ($password){
+					$this->driver->auth($password);
+				}
 
-			$this->driver = new Credis_Client($host, $port, $timeout, $persistent);
-			$this->driver->setMaxConnectRetries($maxRetries);
-			if ($password){
-				$this->driver->auth($password);
+				// If we have found a database in our DSN, use it instead of the `$database`
+				// value passed into the constructor.
+				if ($dsnDatabase !== false) {
+					$database = $dsnDatabase;
+				}
 			}
 
-			// If we have found a database in our DSN, use it instead of the `$database`
-			// value passed into the constructor.
-			if ($dsnDatabase !== false) {
-				$database = $dsnDatabase;
+			if ($database !== null) {
+				$this->driver->select($database);
 			}
 		}
-
-		if ($database !== null) {
-			$this->driver->select($database);
+		catch(CredisException $e) {
+			throw new Resque_RedisException($e);
 		}
 	}
 
@@ -241,7 +245,7 @@ class Resque_Redis
 			return $this->driver->__call($name, $args);
 		}
 		catch (CredisException $e) {
-			return false;
+			throw new Resque_RedisException($e);
 		}
 	}
 

--- a/lib/Resque/RedisException.php
+++ b/lib/Resque/RedisException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Redis related exceptions
+ *
+ * @package		Resque
+ * @author		Chris Boulton <chris@bigcommerce.com>
+ * @license		http://www.opensource.org/licenses/mit-license.php
+ */
+class Resque_RedisException extends Resque_Exception
+{
+}
+?>

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -26,6 +26,15 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$this->assertTrue((bool)Resque::enqueue('jobs', 'Test_Job'));
 	}
 
+	/**
+	 * @expectedException Resque_RedisException
+	 */
+	public function testRedisErrorThrowsExceptionOnJobCreation()
+	{
+		Resque::setBackend('redis://255.255.255.255:1234');
+		Resque::enqueue('jobs', 'This is a test');
+	}
+
 	public function testQeueuedJobCanBeReserved()
 	{
 		Resque::enqueue('jobs', 'Test_Job');

--- a/test/Resque/Tests/RedisTest.php
+++ b/test/Resque/Tests/RedisTest.php
@@ -1,13 +1,21 @@
 <?php
 /**
- * Resque_Redis DSN tests.
+ * Resque_Event tests.
  *
  * @package		Resque/Tests
- * @author		Iskandar Najmuddin <github@iskandar.co.uk>
+ * @author		Chris Boulton <chris@bigcommerce.com>
  * @license		http://www.opensource.org/licenses/mit-license.php
  */
-class Resque_Tests_DsnTest extends Resque_Tests_TestCase
+class Resque_Tests_RedisTest extends Resque_Tests_TestCase
 {
+	/**
+	 * @expectedException Resque_RedisException
+	 */
+	public function testRedisExceptionsAreSurfaced()
+	{
+		$redis = new Resque_Redis('redis://255.255.255.255:1234');
+		$redis->ping();
+	}
 
 	/**
 	 * These DNS strings are considered valid.
@@ -178,5 +186,4 @@ class Resque_Tests_DsnTest extends Resque_Tests_TestCase
 		// The next line should throw an InvalidArgumentException
 		$result = Resque_Redis::parseDsn($dsn);
 	}
-
 }

--- a/test/Resque/Tests/TestCase.php
+++ b/test/Resque/Tests/TestCase.php
@@ -22,6 +22,8 @@ class Resque_Tests_TestCase extends PHPUnit_Framework_TestCase
 		preg_match('#^\s*port\s+([0-9]+)#m', $config, $matches);
 		$this->redis = new Credis_Client('localhost', $matches[1]);
 
+		Resque::setBackend('redis://localhost:' . $matches[1]);
+
 		// Flush redis
 		$this->redis->flushAll();
 	}


### PR DESCRIPTION
This is a first pass at changes to be loud whenever an error talking to Redis occurs, which should hopefully address some of the concerns in #228.

There's no way to differentiate between a connection related error and a general error returned from Redis (key is not of that data type, etc), so here we just throw a generic `Resque_RedisException` for anything we see.

Still need to do a full pass over all the Redis usage to see what behavioral changes we can expect as a result of this.