### PR TITLE
fix wrong return value on extension pcntl_fork not loaded

### DIFF
--- a/lib/Resque.php
+++ b/lib/Resque.php
@@ -77,7 +77,7 @@ class Resque
 	public static function fork()
 	{
 		if(!function_exists('pcntl_fork')) {
-			return -1;
+			return false;
 		}
 
 		// Close the connection to Redis before forking.
@@ -264,12 +264,12 @@ class Resque
 		$originalQueue = 'queue:'. $queue;
 		$tempQueue = $originalQueue. ':temp:'. time();
 		$requeueQueue = $tempQueue. ':requeue';
-		
+
 		// move each item from original queue to temp queue and process it
 		$finished = false;
 		while (!$finished) {
 			$string = self::redis()->rpoplpush($originalQueue, self::redis()->getPrefix() . $tempQueue);
-	
+
 			if (!empty($string)) {
 				if(self::matchItem($string, $items)) {
 					self::redis()->rpop($tempQueue);
@@ -294,7 +294,7 @@ class Resque
 		// remove temp queue and requeue queue
 		self::redis()->del($requeueQueue);
 		self::redis()->del($tempQueue);
-		
+
 		return $counter;
 	}
 


### PR DESCRIPTION
There is a check for return value === false in Resque_Worker but the fork()-method returns "-1" instead which is not handled properly. It looks like fork() is meant to return "false" if pcntl_fork is not loaded