### PR TITLE
prevents workers to stale when redis server went away

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -154,6 +154,21 @@ class Resque_Worker
 			if($this->shutdown) {
 				break;
 			}
+			
+			// is redis still alive?
+			try {
+			    if (Resque::redis()->ping() === false) {
+			        $this->logger->log(Psr\Log\LogLevel::ERROR, 'redis went away. trying to reconnect');
+			        Resque::$redis = null;
+			        usleep($interval * 1000000);
+			        continue;
+			    }
+			} catch (CredisException $e) {
+			    $this->logger->log(Psr\Log\LogLevel::ERROR, 'redis went away. trying to reconnect');
+			    Resque::$redis = null;
+			    usleep($interval * 1000000);
+			    continue;
+			}
 
 			// Attempt to find and reserve a job
 			$job = false;


### PR DESCRIPTION
fix for #180 

unfortunatelly I have no clue, why the first access on redis()->ping() does *not* throw the exception
anyhow this will prevent worker from getting useless after a network failure or redis restart