### PR TITLE
Corrected type in Resque_Job::$payload docblock

### DIFF
--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -19,7 +19,7 @@ class Resque_Job
 	public $worker;
 
 	/**
-	 * @var object Object containing details of the job.
+	 * @var array Array containing details of the job.
 	 */
 	public $payload;
 


### PR DESCRIPTION
The docblock for the $payload property in the Resque_Job class is object, which is inconsistent with the array type used for the corresponding constructor parameter. Other usage of the $payload property, such as in updateStatus(), indicate that array seems to be correct.