### PR TITLE
add PHP 7 and HHVM to TravisCI runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,17 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - hhvm
+  
+matrix:
+    allow_failures:
+        - php: hhvm
+        - php: 7.0
 env:
   - REDIS_STANDALONE=0
   - REDIS_STANDALONE=1
+  
 before_script:
   - sh -c "if [ $REDIS_STANDALONE -eq 0 ]; then wget https://github.com/nicolasff/phpredis/archive/2.2.3.zip -O php-redis.zip && unzip php-redis.zip; fi"
   - sh -c "if [ $REDIS_STANDALONE -eq 0 ]; then cd phpredis-2.2.3/ && phpize && ./configure && make && make install; fi"


### PR DESCRIPTION
A improvement in the tests execution adding PHP7 and HHVM, so we can know if something is breaking in those enviorment.

For now I add this versions to allow failures.