### PR TITLE
Fix OSX worker warning and cli_set_process_title

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -63,7 +63,7 @@ class Resque_Worker
     public function __construct($queues)
     {
         $this->logger = new Resque_Log();
-        
+
         if(!is_array($queues)) {
             $queues = array($queues);
         }

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -327,7 +327,7 @@ class Resque_Worker
 	private function updateProcLine($status)
 	{
 		$processTitle = 'resque-' . Resque::VERSION . ': ' . $status;
-		if(function_exists('cli_set_process_title')) {
+		if(function_exists('cli_set_process_title') && PHP_OS !== 'Darwin') {
 			cli_set_process_title($processTitle);
 		}
 		else if(function_exists('setproctitle')) {


### PR DESCRIPTION
OS X doesn't allow to use cli_set_process_title for security reasons and it keeps warning every cycle.