### PR TITLE
POSIX signals are not working on PHP 7

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -1,4 +1,6 @@
 <?php
+declare(ticks = 1);
+
 /**
  * Resque worker that handles checking queues for jobs, fetching them
  * off the queues, running them and handling the result.
@@ -311,8 +313,6 @@ class Resque_Worker
 	 */
 	private function startup()
 	{
-		declare(ticks = 1);
-		
 		$this->registerSigHandlers();
 		$this->pruneDeadWorkers();
 		Resque_Event::trigger('beforeFirstFork', $this);

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -311,6 +311,8 @@ class Resque_Worker
 	 */
 	private function startup()
 	{
+		declare(ticks = 1);
+		
 		$this->registerSigHandlers();
 		$this->pruneDeadWorkers();
 		Resque_Event::trigger('beforeFirstFork', $this);
@@ -349,7 +351,6 @@ class Resque_Worker
 			return;
 		}
 
-		declare(ticks = 1);
 		pcntl_signal(SIGTERM, array($this, 'shutDownNow'));
 		pcntl_signal(SIGINT, array($this, 'shutDownNow'));
 		pcntl_signal(SIGQUIT, array($this, 'shutdown'));


### PR DESCRIPTION
Having `declare(ticks = 1)` inside `registerSigHandlers()` worked perfectly on PHP 5.6 but it doesn't on PHP 7.

I found it that moving the `declare(ticks = 1)` outside `registerSigHandlers()` solves the issue.

Could this please be merged and tagged ? :)

I found the idea of moving the `declare(ticks = 1)` in this PR: https://github.com/juriansluiman/SlmQueue/pull/175