### PR TITLE
Add support for unprotected unix socket

### DIFF
--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -148,6 +148,7 @@ class Resque_Redis
 	 * - host:port
 	 * - redis://user:pass@host:port/db?option1=val1&option2=val2
 	 * - tcp://user:pass@host:port/db?option1=val1&option2=val2
+	 * - unix:///path/to/redis.sock
 	 *
 	 * Note: the 'user' part of the DSN is not used.
 	 *
@@ -160,6 +161,16 @@ class Resque_Redis
 		if ($dsn == '') {
 			// Use a sensible default for an empty DNS string
 			$dsn = 'redis://' . self::DEFAULT_HOST;
+		}
+		if(substr($dsn, 0, 7) === 'unix://') {
+			return array(
+				$dsn,
+				null,
+				null,
+				null,
+				null,
+				null,
+			);
 		}
 		$parts = parse_url($dsn);
 

--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -166,7 +166,7 @@ class Resque_Redis
 			return array(
 				$dsn,
 				null,
-				null,
+				false,
 				null,
 				null,
 				null,


### PR DESCRIPTION
 - You can now provide a unix socket based redis connection: 
   - `Resque::setBackend('unix:///path/to/redis.sock')`
 - username/password/db in unix socket dsn currently unsupported: 
   - This middle layer for Dsn parsing seemed too clunky for me to introduce user/pass/db parsing for unix sockets.