### PR TITLE
Allowing to use a factory instead of manually instantiate the Jobs

### DIFF
--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -28,10 +28,10 @@ class Resque_Job implements Resque_JobInterface
 	 */
 	private $instance;
 
-    /**
-     * @var Resque_Job_FactoryInterface
-     */
-    private $jobFactory;
+	/**
+	 * @var Resque_Job_FactoryInterface
+	 */
+	private $jobFactory;
 
 	/**
 	 * Instantiate a new instance of a job.
@@ -45,18 +45,18 @@ class Resque_Job implements Resque_JobInterface
 		$this->payload = $payload;
 	}
 
-    /**
-     * Create a new job and save it to the specified queue.
-     *
-     * @param string $queue The name of the queue to place the job in.
-     * @param string $class The name of the class that contains the code to execute the job.
-     * @param array $args Any optional arguments that should be passed when the job is executed.
-     * @param boolean $monitor Set to true to be able to monitor the status of a job.
-     * @param string $id Unique identifier for tracking the job. Generated if not supplied.
-     *
-     * @return string
-     * @throws \InvalidArgumentException
-     */
+	/**
+	 * Create a new job and save it to the specified queue.
+	 *
+	 * @param string $queue The name of the queue to place the job in.
+	 * @param string $class The name of the class that contains the code to execute the job.
+	 * @param array $args Any optional arguments that should be passed when the job is executed.
+	 * @param boolean $monitor Set to true to be able to monitor the status of a job.
+	 * @param string $id Unique identifier for tracking the job. Generated if not supplied.
+	 *
+	 * @return string
+	 * @throws \InvalidArgumentException
+	 */
 	public static function create($queue, $class, $args = null, $monitor = false, $id = null)
 	{
 		if (is_null($id)) {
@@ -82,41 +82,41 @@ class Resque_Job implements Resque_JobInterface
 		return $id;
 	}
 
-    /**
-     * Find the next available job from the specified queue and return an
-     * instance of Resque_Job for it.
-     *
-     * @param string $queue The name of the queue to check for a job in.
-     * @return false|object Null when there aren't any waiting jobs, instance of Resque_Job when a job was found.
-     */
-    public static function reserve($queue)
-    {
-        $payload = Resque::pop($queue);
-        if(!is_array($payload)) {
-            return false;
-        }
+	/**
+	 * Find the next available job from the specified queue and return an
+	 * instance of Resque_Job for it.
+	 *
+	 * @param string $queue The name of the queue to check for a job in.
+	 * @return false|object Null when there aren't any waiting jobs, instance of Resque_Job when a job was found.
+	 */
+	public static function reserve($queue)
+	{
+		$payload = Resque::pop($queue);
+		if(!is_array($payload)) {
+			return false;
+		}
 
-        return new Resque_Job($queue, $payload);
-    }
+		return new Resque_Job($queue, $payload);
+	}
 
-    /**
-     * Find the next available job from the specified queues using blocking list pop
-     * and return an instance of Resque_Job for it.
-     *
-     * @param array             $queues
-     * @param int               $timeout
-     * @return false|object Null when there aren't any waiting jobs, instance of Resque_Job when a job was found.
-     */
-    public static function reserveBlocking(array $queues, $timeout = null)
-    {
-        $item = Resque::blpop($queues, $timeout);
+	/**
+	 * Find the next available job from the specified queues using blocking list pop
+	 * and return an instance of Resque_Job for it.
+	 *
+	 * @param array             $queues
+	 * @param int               $timeout
+	 * @return false|object Null when there aren't any waiting jobs, instance of Resque_Job when a job was found.
+	 */
+	public static function reserveBlocking(array $queues, $timeout = null)
+	{
+		$item = Resque::blpop($queues, $timeout);
 
-        if(!is_array($item)) {
-            return false;
-        }
+		if(!is_array($item)) {
+			return false;
+		}
 
-        return new Resque_Job($item['queue'], $item['payload']);
-    }
+		return new Resque_Job($item['queue'], $item['payload']);
+	}
 
 	/**
 	 * Update the status of the current job.
@@ -158,11 +158,11 @@ class Resque_Job implements Resque_JobInterface
 		return $this->payload['args'][0];
 	}
 
-    /**
-     * Get the instantiated object for this job that will be performing work.
-     * @return Resque_JobInterface Instance of the object that this job belongs to.
-     * @throws Resque_Exception
-     */
+	/**
+	 * Get the instantiated object for this job that will be performing work.
+	 * @return Resque_JobInterface Instance of the object that this job belongs to.
+	 * @throws Resque_Exception
+	 */
 	public function getInstance()
 	{
 		if (!is_null($this->instance)) {
@@ -181,14 +181,14 @@ class Resque_Job implements Resque_JobInterface
 			);
 		}
 
-        if ($this->jobFactory !== null) {
-            $this->instance = $this->jobFactory->create($this->payload['class'], $this->getArguments(), $this->queue);
-            return $this->instance;
-        }
-        $this->instance = new $this->payload['class'];
-        $this->instance->job = $this;
-        $this->instance->args = $this->getArguments();
-        $this->instance->queue = $this->queue;
+		if ($this->jobFactory !== null) {
+			$this->instance = $this->jobFactory->create($this->payload['class'], $this->getArguments(), $this->queue);
+			return $this->instance;
+		}
+		$this->instance = new $this->payload['class'];
+		$this->instance->job = $this;
+		$this->instance->args = $this->getArguments();
+		$this->instance->queue = $this->queue;
 
 		return $this->instance;
 	}
@@ -284,14 +284,14 @@ class Resque_Job implements Resque_JobInterface
 		return '(' . implode(' | ', $name) . ')';
 	}
 
-    /**
-     * @param Resque_Job_FactoryInterface $jobFactory
-     * @return Resque_Job
-     */
-    public function setJobFactory(Resque_Job_FactoryInterface $jobFactory)
-    {
-        $this->jobFactory = $jobFactory;
+	/**
+	 * @param Resque_Job_FactoryInterface $jobFactory
+	 * @return Resque_Job
+	 */
+	public function setJobFactory(Resque_Job_FactoryInterface $jobFactory)
+	{
+		$this->jobFactory = $jobFactory;
 
-        return $this;
-    }
+		return $this;
+	}
 }

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -182,13 +182,14 @@ class Resque_Job implements Resque_JobInterface
 		}
 
         if ($this->jobFactory !== null) {
-            $this->instance = $this->jobFactory->create($this->payload['class']);
-        } else {
-            $this->instance = new $this->payload['class'];
+            $this->instance = $this->jobFactory->create($this->payload['class'], $this->getArguments(), $this->queue);
+            return $this->instance;
         }
-		$this->instance->job = $this;
-		$this->instance->args = $this->getArguments();
-		$this->instance->queue = $this->queue;
+        $this->instance = new $this->payload['class'];
+        $this->instance->job = $this;
+        $this->instance->args = $this->getArguments();
+        $this->instance->queue = $this->queue;
+
 		return $this->instance;
 	}
 

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -182,7 +182,7 @@ class Resque_Job implements Resque_JobInterface
 		}
 
         if ($this->jobFactory !== null) {
-            $this->instance = $this->jobFactory->create();
+            $this->instance = $this->jobFactory->create($this->payload['class']);
         } else {
             $this->instance = new $this->payload['class'];
         }

--- a/lib/Resque/Job/Factory.php
+++ b/lib/Resque/Job/Factory.php
@@ -1,0 +1,32 @@
+<?php
+
+class Resque_Job_Factory implements Resque_Job_FactoryInterface
+{
+
+    /**
+     * @param $className
+     * @param array $args
+     * @param $queue
+     * @return Resque_JobInterface
+     * @throws \Resque_Exception
+     */
+    public function create($className, $args, $queue)
+    {
+        if (!class_exists($className)) {
+            throw new Resque_Exception(
+                'Could not find job class ' . $className . '.'
+            );
+        }
+
+        if (!method_exists($className, 'perform')) {
+            throw new Resque_Exception(
+                'Job class ' . $className . ' does not contain a perform method.'
+            );
+        }
+
+        $instance = new $className;
+        $instance->args = $args;
+        $instance->queue = $queue;
+        return $instance;
+    }
+}

--- a/lib/Resque/Job/FactoryInterface.php
+++ b/lib/Resque/Job/FactoryInterface.php
@@ -3,7 +3,8 @@
 interface Resque_Job_FactoryInterface
 {
     /**
+     * @param $className
      * @return Resque_JobInterface
      */
-    public function create();
+    public function create($className);
 }

--- a/lib/Resque/Job/FactoryInterface.php
+++ b/lib/Resque/Job/FactoryInterface.php
@@ -8,5 +8,5 @@ interface Resque_Job_FactoryInterface
 	 * @param $queue
 	 * @return Resque_JobInterface
 	 */
-	public function create($className, array $args, $queue);
+	public function create($className, $args, $queue);
 }

--- a/lib/Resque/Job/FactoryInterface.php
+++ b/lib/Resque/Job/FactoryInterface.php
@@ -2,11 +2,11 @@
 
 interface Resque_Job_FactoryInterface
 {
-    /**
-     * @param $className
-     * @param array $args
-     * @param $queue
-     * @return Resque_JobInterface
-     */
-    public function create($className, array $args, $queue);
+	/**
+	 * @param $className
+	 * @param array $args
+	 * @param $queue
+	 * @return Resque_JobInterface
+	 */
+	public function create($className, array $args, $queue);
 }

--- a/lib/Resque/Job/FactoryInterface.php
+++ b/lib/Resque/Job/FactoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+interface Resque_Job_FactoryInterface
+{
+    /**
+     * @return Resque_JobInterface
+     */
+    public function create();
+}

--- a/lib/Resque/Job/FactoryInterface.php
+++ b/lib/Resque/Job/FactoryInterface.php
@@ -4,7 +4,9 @@ interface Resque_Job_FactoryInterface
 {
     /**
      * @param $className
+     * @param array $args
+     * @param $queue
      * @return Resque_JobInterface
      */
-    public function create($className);
+    public function create($className, array $args, $queue);
 }

--- a/lib/Resque/JobInterface.php
+++ b/lib/Resque/JobInterface.php
@@ -2,8 +2,8 @@
 
 interface Resque_JobInterface
 {
-    /**
-     * @return bool
-     */
-    public function perform();
+	/**
+	 * @return bool
+	 */
+	public function perform();
 }

--- a/lib/Resque/JobInterface.php
+++ b/lib/Resque/JobInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+interface Resque_JobInterface
+{
+    /**
+     * @return bool
+     */
+    public function perform();
+}

--- a/test/Resque/Tests/EventTest.php
+++ b/test/Resque/Tests/EventTest.php
@@ -31,7 +31,7 @@ class Resque_Tests_EventTest extends Resque_Tests_TestCase
 		$payload = array(
 			'class' => 'Test_Job',
 			'args' => array(
-				'somevar',
+				array('somevar'),
 			),
 		);
 		$job = new Resque_Job('jobs', $payload);

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -365,30 +365,30 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 	public function testUseFactoryToGetJobInstance()
     {
         $payload = array(
-            'class' => Some_Job_Class::class,
+            'class' => 'Some_Job_Class',
             'args' => null
         );
         $job = new Resque_Job('jobs', $payload);
-        $factory = $this->getMock(Resque_Job_FactoryInterface::class);
+        $factory = $this->getMock('Resque_Job_FactoryInterface');
         $job->setJobFactory($factory);
-        $testJob = $this->getMock(Resque_JobInterface::class);
+        $testJob = $this->getMock('Resque_JobInterface');
         $factory->expects(self::once())->method('create')->will($this->returnValue($testJob));
         $instance = $job->getInstance();
-        $this->assertInstanceOf(Resque_JobInterface::class, $instance);
+        $this->assertInstanceOf('Resque_JobInterface', $instance);
     }
 
     public function testDoNotUseFactoryToGetInstance()
     {
         $payload = array(
-            'class' => Some_Job_Class::class,
+            'class' => 'Some_Job_Class',
             'args' => null
         );
         $job = new Resque_Job('jobs', $payload);
-        $factory = $this->getMock(Resque_Job_FactoryInterface::class);
-        $testJob = $this->getMock(Resque_JobInterface::class);
+        $factory = $this->getMock('Resque_Job_FactoryInterface');
+        $testJob = $this->getMock('Resque_JobInterface');
         $factory->expects(self::never())->method('create')->will(self::returnValue($testJob));
         $instance = $job->getInstance();
-        $this->assertInstanceOf(Resque_JobInterface::class, $instance);
+        $this->assertInstanceOf('Resque_JobInterface', $instance);
     }
 }
 

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -183,16 +183,16 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 
 	public function testJobWithNamespace()
 	{
-	    Resque_Redis::prefix('php');
-	    $queue = 'jobs';
-	    $payload = array('another_value');
-        Resque::enqueue($queue, 'Test_Job_With_TearDown', $payload);
-        
-        $this->assertEquals(Resque::queues(), array('jobs'));
-        $this->assertEquals(Resque::size($queue), 1);
+		Resque_Redis::prefix('php');
+		$queue = 'jobs';
+		$payload = array('another_value');
+		Resque::enqueue($queue, 'Test_Job_With_TearDown', $payload);
 
-        Resque_Redis::prefix('resque');
-        $this->assertEquals(Resque::size($queue), 0);        
+		$this->assertEquals(Resque::queues(), array('jobs'));
+		$this->assertEquals(Resque::size($queue), 1);
+
+		Resque_Redis::prefix('resque');
+		$this->assertEquals(Resque::size($queue), 0);
 	}
 
 	public function testDequeueAll()
@@ -363,56 +363,56 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 	}
 
 	public function testUseFactoryToGetJobInstance()
-    {
-        $payload = array(
-            'class' => 'Some_Job_Class',
-            'args' => null
-        );
-        $job = new Resque_Job('jobs', $payload);
-        $factory = new Some_Stub_Factory();
-        $job->setJobFactory($factory);
-        $instance = $job->getInstance();
-        $this->assertInstanceOf('Resque_JobInterface', $instance);
-    }
+	{
+		$payload = array(
+			'class' => 'Some_Job_Class',
+			'args' => null
+		);
+		$job = new Resque_Job('jobs', $payload);
+		$factory = new Some_Stub_Factory();
+		$job->setJobFactory($factory);
+		$instance = $job->getInstance();
+		$this->assertInstanceOf('Resque_JobInterface', $instance);
+	}
 
-    public function testDoNotUseFactoryToGetInstance()
-    {
-        $payload = array(
-            'class' => 'Some_Job_Class',
-            'args' => null
-        );
-        $job = new Resque_Job('jobs', $payload);
-        $factory = $this->getMock('Resque_Job_FactoryInterface');
-        $testJob = $this->getMock('Resque_JobInterface');
-        $factory->expects(self::never())->method('create')->will(self::returnValue($testJob));
-        $instance = $job->getInstance();
-        $this->assertInstanceOf('Resque_JobInterface', $instance);
-    }
+	public function testDoNotUseFactoryToGetInstance()
+	{
+		$payload = array(
+			'class' => 'Some_Job_Class',
+			'args' => null
+		);
+		$job = new Resque_Job('jobs', $payload);
+		$factory = $this->getMock('Resque_Job_FactoryInterface');
+		$testJob = $this->getMock('Resque_JobInterface');
+		$factory->expects(self::never())->method('create')->will(self::returnValue($testJob));
+		$instance = $job->getInstance();
+		$this->assertInstanceOf('Resque_JobInterface', $instance);
+	}
 }
 
 class Some_Job_Class implements Resque_JobInterface
 {
 
-    /**
-     * @return bool
-     */
-    public function perform()
-    {
-        return true;
-    }
+	/**
+	 * @return bool
+	 */
+	public function perform()
+	{
+		return true;
+	}
 }
 
 class Some_Stub_Factory implements Resque_Job_FactoryInterface
 {
 
-    /**
-     * @param $className
-     * @param array $args
-     * @param $queue
-     * @return Resque_JobInterface
-     */
-    public function create($className, array $args, $queue)
-    {
-        return new Some_Job_Class();
-    }
+	/**
+	 * @param $className
+	 * @param array $args
+	 * @param $queue
+	 * @return Resque_JobInterface
+	 */
+	public function create($className, array $args, $queue)
+	{
+		return new Some_Job_Class();
+	}
 }

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -362,11 +362,22 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$this->assertEquals(Resque::size($queue), 2);
 	}
 
-	public function testUseFactoryToGetJobInstance()
+	public function testUseDefaultFactoryToGetJobInstance()
 	{
 		$payload = array(
 			'class' => 'Some_Job_Class',
 			'args' => null
+		);
+		$job = new Resque_Job('jobs', $payload);
+		$instance = $job->getInstance();
+		$this->assertInstanceOf('Some_Job_Class', $instance);
+	}
+
+	public function testUseFactoryToGetJobInstance()
+	{
+		$payload = array(
+			'class' => 'Some_Job_Class',
+			'args' => array(array())
 		);
 		$job = new Resque_Job('jobs', $payload);
 		$factory = new Some_Stub_Factory();
@@ -379,7 +390,7 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 	{
 		$payload = array(
 			'class' => 'Some_Job_Class',
-			'args' => null
+			'args' => array(array())
 		);
 		$job = new Resque_Job('jobs', $payload);
 		$factory = $this->getMock('Resque_Job_FactoryInterface');
@@ -411,7 +422,7 @@ class Some_Stub_Factory implements Resque_Job_FactoryInterface
 	 * @param $queue
 	 * @return Resque_JobInterface
 	 */
-	public function create($className, array $args, $queue)
+	public function create($className, $args, $queue)
 	{
 		return new Some_Job_Class();
 	}

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -369,10 +369,8 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
             'args' => null
         );
         $job = new Resque_Job('jobs', $payload);
-        $factory = $this->getMock('Resque_Job_FactoryInterface');
+        $factory = new Some_Stub_Factory();
         $job->setJobFactory($factory);
-        $testJob = $this->getMock('Resque_JobInterface');
-        $factory->expects(self::once())->method('create')->will($this->returnValue($testJob));
         $instance = $job->getInstance();
         $this->assertInstanceOf('Resque_JobInterface', $instance);
     }
@@ -401,5 +399,20 @@ class Some_Job_Class implements Resque_JobInterface
     public function perform()
     {
         return true;
+    }
+}
+
+class Some_Stub_Factory implements Resque_Job_FactoryInterface
+{
+
+    /**
+     * @param $className
+     * @param array $args
+     * @param $queue
+     * @return Resque_JobInterface
+     */
+    public function create($className, array $args, $queue)
+    {
+        return new Some_Job_Class();
     }
 }

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -362,4 +362,44 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$this->assertEquals(Resque::size($queue), 2);
 	}
 
+	public function testUseFactoryToGetJobInstance()
+    {
+        $payload = array(
+            'class' => Some_Job_Class::class,
+            'args' => null
+        );
+        $job = new Resque_Job('jobs', $payload);
+        $factory = $this->getMock(Resque_Job_FactoryInterface::class);
+        $job->setJobFactory($factory);
+        $testJob = $this->getMock(Resque_JobInterface::class);
+        $factory->expects(self::once())->method('create')->will($this->returnValue($testJob));
+        $instance = $job->getInstance();
+        $this->assertInstanceOf(Resque_JobInterface::class, $instance);
+    }
+
+    public function testDoNotUseFactoryToGetInstance()
+    {
+        $payload = array(
+            'class' => Some_Job_Class::class,
+            'args' => null
+        );
+        $job = new Resque_Job('jobs', $payload);
+        $factory = $this->getMock(Resque_Job_FactoryInterface::class);
+        $testJob = $this->getMock(Resque_JobInterface::class);
+        $factory->expects(self::never())->method('create')->will(self::returnValue($testJob));
+        $instance = $job->getInstance();
+        $this->assertInstanceOf(Resque_JobInterface::class, $instance);
+    }
+}
+
+class Some_Job_Class implements Resque_JobInterface
+{
+
+    /**
+     * @return bool
+     */
+    public function perform()
+    {
+        return true;
+    }
 }

--- a/test/Resque/Tests/TestCase.php
+++ b/test/Resque/Tests/TestCase.php
@@ -11,6 +11,11 @@ class Resque_Tests_TestCase extends PHPUnit_Framework_TestCase
 	protected $resque;
 	protected $redis;
 
+    public static function setUpBeforeClass()
+    {
+        date_default_timezone_set('UTC');
+    }
+
 	public function setUp()
 	{
 		$config = file_get_contents(REDIS_CONF);

--- a/test/Resque/Tests/TestCase.php
+++ b/test/Resque/Tests/TestCase.php
@@ -11,10 +11,10 @@ class Resque_Tests_TestCase extends PHPUnit_Framework_TestCase
 	protected $resque;
 	protected $redis;
 
-    public static function setUpBeforeClass()
-    {
-        date_default_timezone_set('UTC');
-    }
+	public static function setUpBeforeClass()
+	{
+		date_default_timezone_set('UTC');
+	}
 
 	public function setUp()
 	{


### PR DESCRIPTION
In order to make the Jobs injectable, I want to allow to delegate the responsibility of create new jobs to an independent factory. In that way, if I want to use Pimple, I can do so using a factory that will encapsulate access to Pimple to retrieve instances of `Resque_JobInterface`

I kept it as PSR-0 and I have added a couple of tests