### PR TITLE
Allow empty prefix

### DIFF
--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -98,7 +98,7 @@ class Resque_Redis
 	 */
 	public static function prefix($namespace)
 	{
-	    if (substr($namespace, -1) !== ':') {
+	    if (substr($namespace, -1) !== ':' and $namespace != '') {
 	        $namespace .= ':';
 	    }
 	    self::$defaultNamespace = $namespace;


### PR DESCRIPTION
We should check to see if a user has chosen to not add a prefix and not append ":" if so.