### PR TITLE
Remove old PHP versions from test matrix, require PHP 7 and HHVM to pass as these are now officially supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,11 @@
 language: php
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - hhvm
-  
-matrix:
-    allow_failures:
-        - php: hhvm
-        - php: 7.0
 env:
   - REDIS_STANDALONE=0
   - REDIS_STANDALONE=1
-  
 before_script:
   - sh -c "if [ $REDIS_STANDALONE -eq 0 ]; then wget https://github.com/nicolasff/phpredis/archive/2.2.3.zip -O php-redis.zip && unzip php-redis.zip; fi"
   - sh -c "if [ $REDIS_STANDALONE -eq 0 ]; then cd phpredis-2.2.3/ && phpize && ./configure && make && make install; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: php
-php:
-  - 5.6
-  - 7.0
-  - hhvm
-env:
-  - REDIS_STANDALONE=0
-  - REDIS_STANDALONE=1
+matrix:
+  include:
+    - php: 5.6
+      env: ENABLE_REDIS_EXT=0
+    - php: 5.6
+      env: ENABLE_REDIS_EXT=1
+    - php: 7.0
+      env: ENABLE_REDIS_EXT=0
+    - php: 7.0
+      env: ENABLE_REDIS_EXT=1
+    - php: hhvm
+      env: ENABLE_REDIS_EXT=0
 before_script:
-  - sh -c "if [ $REDIS_STANDALONE -eq 0 ]; then wget https://github.com/nicolasff/phpredis/archive/2.2.3.zip -O php-redis.zip && unzip php-redis.zip; fi"
-  - sh -c "if [ $REDIS_STANDALONE -eq 0 ]; then cd phpredis-2.2.3/ && phpize && ./configure && make && make install; fi"
-  - sh -c "if [ $REDIS_STANDALONE -eq 0 ]; then echo \"extension=redis.so\" >> `php --ini | grep \"Loaded Configuration\" | sed -e \"s|.*:\s*||\"`; fi"
+  - sh -c "if [ $ENABLE_REDIS_EXT -eq 1 ]; then echo \"extension=redis.so\" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
   - composer install


### PR DESCRIPTION
Moves away from using the existing matrix into a new one with the explicit combinations, only because with HHVM Redis is bundled and enabled by default.