### PR TITLE
Use Matrix Exclude instead of hard-coded matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: php
+php:
+  - 5.6
+  - 7.0
+  - hhvm
 matrix:
-  include:
-    - php: 5.6
-      env: ENABLE_REDIS_EXT=0
-    - php: 5.6
-      env: ENABLE_REDIS_EXT=1
-    - php: 7.0
-      env: ENABLE_REDIS_EXT=0
-    - php: 7.0
-      env: ENABLE_REDIS_EXT=1
+  exclude:
     - php: hhvm
-      env: ENABLE_REDIS_EXT=0
+      env: ENABLE_REDIS_EXT=1
+env:
+  - ENABLE_REDIS_EXT=0
+  - ENABLE_REDIS_EXT=1
 before_script:
   - sh -c "if [ $ENABLE_REDIS_EXT -eq 1 ]; then echo \"extension=redis.so\" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
   - composer install


### PR DESCRIPTION
While the current .travis.yml setup works, and the reasoning makes sense, it's far less readable than the previous configuration.  This suggested patch presents an alternative approach to the same result, which uses the matrix->exclude array to filter out invalid tests, instead of hard-coding every valid combination as the current file does.  This seems more readable, at least to me.