### PR TITLE
Use a mock to test correct redis exceptions are surfaced

### DIFF
--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -108,12 +108,16 @@ class Resque_Redis
 	 * @param string|array $server A DSN or array
 	 * @param int $database A database number to select. However, if we find a valid database number in the DSN the
 	 *                      DSN-supplied value will be used instead and this parameter is ignored.
+	 * @param object $client Optional Credis_Cluster or Credis_Client instance instantiated by you
 	 */
-    public function __construct($server, $database = null)
+    public function __construct($server, $database = null, $client = null)
 	{
 		try {
 			if (is_array($server)) {
 				$this->driver = new Credis_Cluster($server);
+			}
+			else if (is_object($client)) {
+				$this->driver = $client;
 			}
 			else {
 				list($host, $port, $dsnDatabase, $user, $password, $options) = self::parseDsn($server);

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -31,7 +31,15 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 	 */
 	public function testRedisErrorThrowsExceptionOnJobCreation()
 	{
-		Resque::setBackend('redis://255.255.255.255:1234');
+		$mockCredis = $this->getMockBuilder('Credis_Client')
+			->setMethods(['connect', '__call'])
+			->getMock();
+		$mockCredis->expects($this->any())->method('__call')
+			->will($this->throwException(new CredisException('failure')));
+
+		Resque::setBackend(function($database) use ($mockCredis) {
+			return new Resque_Redis('localhost:6379', $database, $mockCredis);
+		});
 		Resque::enqueue('jobs', 'This is a test');
 	}
 

--- a/test/Resque/Tests/RedisTest.php
+++ b/test/Resque/Tests/RedisTest.php
@@ -13,8 +13,16 @@ class Resque_Tests_RedisTest extends Resque_Tests_TestCase
 	 */
 	public function testRedisExceptionsAreSurfaced()
 	{
-		$redis = new Resque_Redis('redis://255.255.255.255:1234');
-		$redis->ping();
+		$mockCredis = $this->getMockBuilder('Credis_Client')
+			->setMethods(['connect', '__call'])
+			->getMock();
+		$mockCredis->expects($this->any())->method('__call')
+			->will($this->throwException(new CredisException('failure')));
+
+		Resque::setBackend(function($database) use ($mockCredis) {
+			return new Resque_Redis('localhost:6379', $database, $mockCredis);
+		});
+		Resque::redis()->ping();
 	}
 
 	/**


### PR DESCRIPTION
Rather than passing a fake/bad network address for these tests, I should probably mock Credis instead.