### PR TITLE
PHP 7 Errors + PSR-3 exception logging

### DIFF
--- a/lib/Resque/Failure.php
+++ b/lib/Resque/Failure.php
@@ -29,6 +29,20 @@ class Resque_Failure
 	}
 
 	/**
+	 * Create a new failed job on the backend from PHP 7 errors.
+	 *
+	 * @param object $payload        The contents of the job that has just failed.
+	 * @param \Error $exception  The PHP 7 error generated when the job failed to run.
+	 * @param \Resque_Worker $worker Instance of Resque_Worker that was running this job when it failed.
+	 * @param string $queue          The name of the queue that this job was fetched from.
+	 */
+	public static function createFromError($payload, Error $exception, Resque_Worker $worker, $queue)
+	{
+		$backend = self::getBackend();
+		new $backend($payload, $exception, $worker, $queue);
+	}
+
+	/**
 	 * Return an instance of the backend for saving job failures.
 	 *
 	 * @return object Instance of backend object.

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -220,12 +220,21 @@ class Resque_Job
 		));
 
 		$this->updateStatus(Resque_Job_Status::STATUS_FAILED);
-		Resque_Failure::create(
-			$this->payload,
-			$exception,
-			$this->worker,
-			$this->queue
-		);
+		if ($exception instanceof Error) {
+			Resque_Failure::createFromError(
+				$this->payload,
+				$exception,
+				$this->worker,
+				$this->queue
+			);
+		} else {
+			Resque_Failure::create(
+				$this->payload,
+				$exception,
+				$this->worker,
+				$this->queue
+			);
+		}
 		Resque_Stat::incr('failed');
 		Resque_Stat::incr('failed:' . $this->worker);
 	}

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -240,7 +240,12 @@ class Resque_Worker
 			$job->perform();
 		}
 		catch(Exception $e) {
-			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => $e));
+			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {exception}', array('job' => $job, 'exception' => $e));
+			$job->fail($e);
+			return;
+		}
+		catch(Error $e) {
+			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {exception}', array('job' => $job, 'exception' => $e));
 			$job->fail($e);
 			return;
 		}


### PR DESCRIPTION
Hey Chris, thanks for building php-resque! In this PR I've added support for catching PHP 7 errors when performing jobs in Resque_Worker. This should not break compatibility with PHP 5.

I've also changed the key name name used to log the exception from `stack` to `exception`. According to [PSR-3](http://www.php-fig.org/psr/psr-3/#1-3-context):
> If an Exception object is passed in the context data, it MUST be in the 'exception' key. 