### PR TITLE
Composer locks due to psr/log dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"php": ">=5.3.0",
 		"ext-pcntl": "*",
 		"colinmollenhour/credis": "~1.7",
-		"psr/log": "1.0.0"
+		"psr/log": "~1.0"
 	},
 	"suggest": {
 		"ext-proctitle": "Allows php-resque to rename the title of UNIX processes to show the status of a worker.",


### PR DESCRIPTION
I get a composer error while trying to require `resquebundle/resque` which uses `chrisboulton/php-resque`

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Can only install one of: psr/log[1.0.2, 1.0.0].
    - Can only install one of: psr/log[1.0.0, 1.0.2].
    - Can only install one of: psr/log[1.0.0, 1.0.2].
    - chrisboulton/php-resque dev-master requires psr/log 1.0.0 -> satisfiable by psr/log[1.0.0].
    - resquebundle/resque dev-master requires chrisboulton/php-resque dev-master -> satisfiable by chrisboulton/php-resque[dev-master].
    - Installation request for resquebundle/resque dev-master -> satisfiable by resquebundle/resque[dev-master].
    - Installation request for psr/log (locked at 1.0.2) -> satisfiable by psr/log[1.0.2].
```

This is resulted because I already have a package which uses psr/log 1.0.2 and `chrisboulton/php-resque` uses psr/log 1.0.0.. can you guys change it to "~1.0"? 


Thanks in advance,
Din.
