### PR TITLE
use a variable to store process name prefix

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -12,6 +12,11 @@ declare(ticks = 1);
 class Resque_Worker
 {
 	/**
+	 * @var string Prefix for the process name
+	 */
+	public static $processPrefix = 'resque-';
+
+	/**
 	* @var LoggerInterface Logging object that impliments the PSR-3 LoggerInterface
 	*/
 	public $logger;
@@ -323,7 +328,7 @@ class Resque_Worker
 	 */
 	private function updateProcLine($status)
 	{
-		$processTitle = 'resque-' . Resque::VERSION . ': ' . $status;
+		$processTitle = static::$processPrefix . Resque::VERSION . ': ' . $status;
 		if(function_exists('cli_set_process_title') && PHP_OS !== 'Darwin') {
 			cli_set_process_title($processTitle);
 		}

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -14,7 +14,7 @@ class Resque_Worker
 	/**
 	 * @var string Prefix for the process name
 	 */
-	public static $processPrefix = 'resque-';
+	private static $processPrefix = 'resque-';
 
 	/**
 	* @var LoggerInterface Logging object that impliments the PSR-3 LoggerInterface
@@ -80,6 +80,15 @@ class Resque_Worker
 
         $this->id = $this->hostname . ':'.getmypid() . ':' . implode(',', $this->queues);
     }
+
+	/**
+	 * Set the process prefix of the workers to the given prefix string.
+	 * @param string $prefix The new process prefix
+	 */
+	public static function setProcessPrefix($prefix)
+	{
+		self::$processPrefix = $prefix;
+	}
 
 	/**
 	 * Return all workers known to Resque as instantiated instances.


### PR DESCRIPTION
This variable removes the magic string, allowing specification through hooks.
In our own environment we run this code `beforeFirstFork`:
```php
$worker::$processPrefix = sprintf('%s%s-', $worker::$processPrefix, $prefix);
```

We like to be able to see environment differences in `top` and `ps a` because we have different users running different instances on the same server.
