### PR TITLE
Add Reserver concept to allow different behaviours for reservation of jobs.

### DIFF
--- a/bin/resque
+++ b/bin/resque
@@ -9,15 +9,15 @@ $files = array(
     __DIR__ . '/../vendor/autoload.php',
 );
 
-$found = false;
+$loader = null;
 foreach ($files as $file) {
     if (file_exists($file)) {
-        require_once $file;
+        $loader = require_once $file;
         break;
     }
 }
 
-if (!class_exists('Composer\Autoload\ClassLoader', false)) {
+if (!($loader instanceof Composer\Autoload\ClassLoader)) {
     die(
         'You need to set up the project dependencies using the following commands:' . PHP_EOL .
             'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
@@ -44,10 +44,11 @@ $REDIS_BACKEND = getenv('REDIS_BACKEND');
 // A redis database number
 $REDIS_BACKEND_DB = getenv('REDIS_BACKEND_DB');
 if(!empty($REDIS_BACKEND)) {
-    if (empty($REDIS_BACKEND_DB))
+    if (empty($REDIS_BACKEND_DB)) {
         Resque::setBackend($REDIS_BACKEND);
-    else
+    } else {
         Resque::setBackend($REDIS_BACKEND, $REDIS_BACKEND_DB);
+    }
 }
 
 $logLevel = false;
@@ -69,6 +70,9 @@ if($APP_INCLUDE) {
 
     require_once $APP_INCLUDE;
 }
+
+// re-register the composer autoloader so that we use Resque here, in case APP_INCLUDE depends on a different version
+$loader->register(true);
 
 // See if the APP_INCLUDE containes a logger object,
 // If none exists, fallback to internal logger

--- a/bin/resque
+++ b/bin/resque
@@ -25,6 +25,9 @@ if (!class_exists('Composer\Autoload\ClassLoader', false)) {
     );
 }
 
+use Resque\Reserver\ReserverFactory;
+use Resque\Reserver\UnknownReserverException;
+
 $QUEUE = getenv('QUEUE');
 if(empty($QUEUE)) {
     die("Set QUEUE env var containing the list of queues to work.\n");
@@ -73,7 +76,22 @@ if (!isset($logger) || !is_object($logger)) {
     $logger = new Resque_Log($logLevel);
 }
 
-$BLOCKING = getenv('BLOCKING') !== FALSE;
+$reserverFactory = new ReserverFactory($logger);
+Resque_Worker::setReserverFactory($reserverFactory);
+
+$queues = explode(',', $QUEUE);
+if (!is_array($queues)) {
+    $queues = array($queues);
+}
+
+$reserver = null;
+try {
+    $reserver = $reserverFactory->createReserverFromEnvironment($queues);
+} catch (UnknownReserverException $exception) {
+    $logger->emergency("Could not create reserver: {error}", ['error' => $exception->getMessage()]);
+    die;
+}
+
 
 $interval = 5;
 $INTERVAL = getenv('INTERVAL');
@@ -102,19 +120,17 @@ if($count > 1) {
         }
         // Child, start the worker
         else if(!$pid) {
-            $queues = explode(',', $QUEUE);
-            $worker = new Resque_Worker($queues);
+            $worker = new Resque_Worker($reserver, $queues);
             $worker->setLogger($logger);
             $logger->log(Psr\Log\LogLevel::NOTICE, 'Starting worker {worker}', array('worker' => $worker));
-            $worker->work($interval, $BLOCKING);
+            $worker->work($interval);
             break;
         }
     }
 }
 // Start a single worker
 else {
-    $queues = explode(',', $QUEUE);
-    $worker = new Resque_Worker($queues);
+    $worker = new Resque_Worker($reserver, $queues);
     $worker->setLogger($logger);
 
     $PIDFILE = getenv('PIDFILE');
@@ -124,6 +140,5 @@ else {
     }
 
     $logger->log(Psr\Log\LogLevel::NOTICE, 'Starting worker {worker}', array('worker' => $worker));
-    $worker->work($interval, $BLOCKING);
+    $worker->work($interval);
 }
-?>

--- a/bin/resque
+++ b/bin/resque
@@ -91,6 +91,7 @@ if (!is_array($queues)) {
 $reserver = null;
 try {
     $reserver = $reserverFactory->createReserverFromEnvironment($queues);
+    $logger->notice('Using reserver {reserver}', array('reserver' => $reserver->getName()));
 } catch (UnknownReserverException $exception) {
     $logger->emergency("Could not create reserver: {error}", ['error' => $exception->getMessage()]);
     die;

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,10 @@
 		"psr-0": {
 			"Resque": "lib"
 		}
+	},
+	"autoload-dev": {
+		"psr-0": {
+			"Resque": "test/"
+		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "41124ffd15a15b52947e430b92b8f10f",
     "content-hash": "11906622d4e017ff6807c6dff51f208d",
     "packages": [
         {
             "name": "colinmollenhour/credis",
-            "version": "1.7",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/colinmollenhour/credis.git",
-                "reference": "74b2b703da5c58dc07fb97e8954bc63280b469bf"
+                "reference": "215810e7161748a99dbc37020d38068a80aa0805"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/74b2b703da5c58dc07fb97e8954bc63280b469bf",
-                "reference": "74b2b703da5c58dc07fb97e8954bc63280b469bf",
+                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/215810e7161748a99dbc37020d38068a80aa0805",
+                "reference": "215810e7161748a99dbc37020d38068a80aa0805",
                 "shasum": ""
             },
             "require": {
@@ -44,7 +43,7 @@
             ],
             "description": "Credis is a lightweight interface to the Redis key-value store which wraps the phpredis library when available for better performance.",
             "homepage": "https://github.com/colinmollenhour/credis",
-            "time": "2016-03-24 15:50:52"
+            "time": "2017-03-25T03:27:34+00:00"
         },
         {
             "name": "psr/log",
@@ -82,7 +81,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2012-12-21T11:40:51+00:00"
         }
     ],
     "packages-dev": [
@@ -145,20 +144,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-09-02 10:13:14"
+            "time": "2014-09-02T10:13:14+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -192,7 +191,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -233,29 +232,34 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -277,7 +281,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -327,7 +331,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2014-03-03 05:10:30"
+            "time": "2014-03-03T05:10:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -400,7 +404,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-10-17 09:04:17"
+            "time": "2014-10-17T09:04:17+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -449,20 +453,20 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2013-01-13 10:24:48"
+            "time": "2013-01-13T10:24:48+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.12",
+            "version": "v2.8.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c"
+                "reference": "286d84891690b0e2515874717e49360d1c98a703"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
-                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/286d84891690b0e2515874717e49360d1c98a703",
+                "reference": "286d84891690b0e2515874717e49360d1c98a703",
                 "shasum": ""
             },
             "require": {
@@ -498,7 +502,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-02 01:57:56"
+            "time": "2017-03-20T09:41:44+00:00"
         }
     ],
     "aliases": [],

--- a/lib/Resque/Reserver/AbstractReserver.php
+++ b/lib/Resque/Reserver/AbstractReserver.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Resque\Reserver;
+
+use Resque_Job;
+use Psr\Log\LoggerInterface;
+use Resque;
+
+abstract class AbstractReserver implements ReserverInterface
+{
+    /** @var array */
+    private $queues;
+
+    /** @var LoggerInterface */
+    protected $logger;
+
+    /**
+     * @param LoggerInterface $logger
+     * @param array $queues The queues to reserve from. If this contains '*', then the queues are retrieved dynamically
+     * from redis on each call to reserve().
+     */
+    public function __construct(LoggerInterface $logger, array $queues)
+    {
+        $this->logger = $logger;
+        $this->queues = $queues;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getQueues()
+    {
+        if (in_array('*', $this->queues)) {
+            $queues = Resque::queues();
+    		sort($queues);
+            return $queues;
+        }
+
+        return $this->queues;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function waitAfterReservationAttempt()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        $name = get_class($this);
+        $name = str_replace(__NAMESPACE__, '', $name);
+        return trim($name, '\\');
+    }
+}

--- a/lib/Resque/Reserver/BlockingListPopReserver.php
+++ b/lib/Resque/Reserver/BlockingListPopReserver.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Resque\Reserver;
+
+use Resque_Job;
+use Psr\Log\LoggerInterface;
+
+/**
+ * BlockingListPopReserver uses the blocking list pop command in redis (https://redis.io/commands/blpop) to wait for a
+ * job to become available on any of the given queues.
+ * This also behaves similarly to QueueOrderReserver in that the queues are checked in the order they are given.
+ *
+ * Environment variables:
+ * - BLPOP_TIMEOUT: The maximum time in seconds that the bplop command should block while waiting for a job.
+ * upon timeout, the worker will attempt to immediately reserve a job again. If zero is specified, the command will
+ * block indefinitely. If not specified, the value of the INTERVAL variable will be used which defaults to 5 seconds.
+ */
+class BlockingListPopReserver extends AbstractReserver implements ReserverInterface
+{
+    /** @var int */
+    const DEFAULT_TIMEOUT = 5;
+
+    /**
+     * @param LoggerInterface $logger
+     * @param array $queues The queues to reserve from. If null, then the queues are retrieved dynamically from redis
+     * on each call to reserve().
+     * @param int $timeout The number of seconds to wait for a job to be enqueued. A timeout of zero will block
+     * indefinitely.
+     */
+    public function __construct(LoggerInterface $logger, array $queues, $timeout = self::DEFAULT_TIMEOUT)
+    {
+        $this->timeout = $timeout;
+        parent::__construct($logger, $queues);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function reserve()
+    {
+        $job = Resque_Job::reserveBlocking($this->getQueues(), $this->timeout);
+        if ($job) {
+            $this->logger->info("[{reserver}] Found job on queue '{queue}'", array(
+                'queue'    => $job->queue,
+                'reserver' => $this->getName(),
+            ));
+            return $job;
+        }
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function waitAfterReservationAttempt()
+    {
+        return false;
+    }
+}

--- a/lib/Resque/Reserver/QueueOrderReserver.php
+++ b/lib/Resque/Reserver/QueueOrderReserver.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Resque\Reserver;
+
+use Resque_Job;
+
+/**
+ * QueueOrderReserver reserves jobs in the order that the queues is given. As long as jobs exist in a higher priority
+ * queue, they will continue to be reserved before moving to the next lowest priority queue.
+ *
+ * For example: given queues A, B and C, all the jobs from queue A will be processed before moving onto queue B and
+ * then after that queue C.
+ *
+ * This is the default reserver.
+ */
+class QueueOrderReserver extends AbstractReserver implements ReserverInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function reserve()
+    {
+        foreach ($this->getQueues() as $queue) {
+            $this->logger->debug("[{reserver}] Checking queue '{queue}' for jobs", array(
+                'queue'    => $queue,
+                'reserver' => $this->getName(),
+            ));
+
+            $job = Resque_Job::reserve($queue);
+            if ($job) {
+                $this->logger->info("[{reserver}] Found job on queue '{queue}'", array(
+                    'queue'    => $queue,
+                    'reserver' => $this->getName(),
+                ));
+                return $job;
+            }
+        }
+
+        return null;
+    }
+}

--- a/lib/Resque/Reserver/RandomQueueOrderReserver.php
+++ b/lib/Resque/Reserver/RandomQueueOrderReserver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Resque\Reserver;
+
+/**
+ * RandomQueueOrderReserver randomises the list of queues before then reserving a job off the first available queue.
+ */
+class RandomQueueOrderReserver extends QueueOrderReserver implements ReserverInterface
+{
+    /**
+     * Gets the queues to reserve jobs from in random order.
+     *
+     * @return array
+     */
+    public function getQueues()
+    {
+        $queues = parent::getQueues();
+        shuffle($queues);
+        return $queues;
+    }
+}

--- a/lib/Resque/Reserver/ReserverFactory.php
+++ b/lib/Resque/Reserver/ReserverFactory.php
@@ -44,6 +44,32 @@ class ReserverFactory
     }
 
     /**
+     * Creates a reserver based off the environment configuration.
+     *
+     * The following environment vars are checked (in this order):
+     * - BLOCKING: Creates a BlockingListPopReserver (any non empty value)
+     * - RESERVER: Creates a reserver specified in snake case format without the reserver suffix, eg. 'random_queue_order'
+     *
+     * If neither var is specified, the default resever (QueueOrderReserver) is created.
+     *
+     * @param array $queues
+     * @return ReserverInterface
+     * @throws UnknownReserverException If the reserver specified in RESERVER could not be found.
+     */
+    public function createReserverFromEnvironment(array $queues)
+    {
+        if (!empty(getenv('BLOCKING'))) {
+            $reserver = $this->createBlockingListPopReserver($queues);
+        } elseif (getenv('RESERVER') !== false) {
+            $reserver = $this->createReserverFromName((string)getenv('RESERVER'), $queues);
+        } else {
+            $reserver = $this->createDefaultReserver($queues);
+        }
+
+        return $reserver;
+    }
+
+    /**
      * Creates the default reserver.
      *
      * @param array $queues

--- a/lib/Resque/Reserver/ReserverFactory.php
+++ b/lib/Resque/Reserver/ReserverFactory.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Resque\Reserver;
+
+use Psr\Log\LoggerInterface;
+
+class ReserverFactory
+{
+    /** @var string */
+    const DEFAULT_RESERVER = 'queue_order';
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Creates a reserver given its name in snake case format.
+     *
+     * @param string $name
+     * @return ReserverInterface
+     * @throws UnknownReserverException
+     */
+    public function createReserverFromName($name, array $queues)
+    {
+        $parts = explode('_', $name);
+        $parts = array_map(function ($word) {
+            return ucfirst(strtolower($word));
+        }, $parts);
+
+        $methodName = 'create' . implode('', $parts) . 'Reserver';
+
+        if (!method_exists($this, $methodName)) {
+            throw new UnknownReserverException("Unknown reserver '$name' - could not find factory method $methodName");
+        }
+
+        return $this->$methodName($queues);
+    }
+
+    /**
+     * Creates the default reserver.
+     *
+     * @param array $queues
+     * @return ReserverInterface
+     */
+    public function createDefaultReserver(array $queues)
+    {
+        return $this->createReserverFromName(self::DEFAULT_RESERVER, $queues);
+    }
+
+    /**
+     * @param array $queues
+     * @return QueueOrderReserver
+     */
+    public function createQueueOrderReserver(array $queues)
+    {
+        return new QueueOrderReserver($this->logger, $queues);
+    }
+
+    /**
+     * @param array $queues
+     * @return RandomQueueOrderReserver
+     */
+    public function createRandomQueueOrderReserver(array $queues)
+    {
+        return new RandomQueueOrderReserver($this->logger, $queues);
+    }
+
+    /**
+     * @param array $queues
+     * @return BlockingListPopReserver
+     */
+    public function createBlockingListPopReserver(array $queues)
+    {
+        $timeout = getenv('BPLOP_TIMEOUT');
+        if ($timeout === false) {
+            $timeout = getenv('INTERVAL');
+        }
+
+        if ($timeout === false || $timeout < 0) {
+            $timeout = BlockingListPopReserver::DEFAULT_TIMEOUT;
+        }
+
+        return new BlockingListPopReserver($this->logger, $queues, (int)$timeout);
+    }
+}

--- a/lib/Resque/Reserver/ReserverInterface.php
+++ b/lib/Resque/Reserver/ReserverInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Resque\Reserver;
+
+use Resque_Job;
+
+/**
+ * A reserver implements a specific behaviour for reserving jobs from its queues.
+ * Resque_Worker will call the reserve() method to obtain a reserved job.
+ */
+interface ReserverInterface
+{
+    /**
+     * Gets the queues to reserve jobs from.
+     *
+     * @return array
+     */
+    public function getQueues();
+
+    /**
+     * Reserves a job.
+     *
+     * @return Resque_Job|null A job instance or null if not job was available to reserve.
+     */
+    public function reserve();
+
+    /**
+     * If there was no job available to reserve, should the worker wait before attempting to reserve a job again?
+     *
+     * @return bool
+     */
+    public function waitAfterReservationAttempt();
+
+    /**
+     * Gets a friendly name of this reserver.
+     *
+     * @return string
+     */
+    public function getName();
+}

--- a/lib/Resque/Reserver/UnknownReserverException.php
+++ b/lib/Resque/Reserver/UnknownReserverException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Resque\Reserver;
+
+class UnknownReserverException extends \UnexpectedValueException
+{
+    /**
+     * @param string $reserver The name of the reserver.
+     */
+    public function __construct($reserver)
+    {
+        parent::__construct("Unknown reserver '$reserver'");
+    }
+}

--- a/test/Resque/Tests/EventTest.php
+++ b/test/Resque/Tests/EventTest.php
@@ -1,4 +1,7 @@
 <?php
+
+use Resque\Reserver\ReserverFactory;
+
 /**
  * Resque_Event tests.
  *
@@ -14,9 +17,13 @@ class Resque_Tests_EventTest extends Resque_Tests_TestCase
 	{
 		Test_Job::$called = false;
 
+		$logger = new Resque_Log();
+		$reserverFactory = new ReserverFactory($logger);
+		$reserver = $reserverFactory->createDefaultReserver(array('jobs'));
+
 		// Register a worker to test with
-		$this->worker = new Resque_Worker('jobs');
-		$this->worker->setLogger(new Resque_Log());
+		$this->worker = new Resque_Worker($reserver, 'jobs');
+		$this->worker->setLogger($logger);
 		$this->worker->registerWorker();
 	}
 

--- a/test/Resque/Tests/JobStatusTest.php
+++ b/test/Resque/Tests/JobStatusTest.php
@@ -1,4 +1,7 @@
 <?php
+
+use Resque\Reserver\ReserverFactory;
+
 /**
  * Resque_Job_Status tests.
  *
@@ -17,9 +20,13 @@ class Resque_Tests_JobStatusTest extends Resque_Tests_TestCase
 	{
 		parent::setUp();
 
+        $logger = new Resque_Log();
+        $reserverFactory = new ReserverFactory($logger);
+        $reserver = $reserverFactory->createDefaultReserver(array('jobs'));
+
 		// Register a worker to test with
-		$this->worker = new Resque_Worker('jobs');
-		$this->worker->setLogger(new Resque_Log());
+		$this->worker = new Resque_Worker($reserver, 'jobs');
+		$this->worker->setLogger($logger);
 	}
 
 	public function testJobStatusCanBeTracked()

--- a/test/Resque/Tests/Reserver/AbstractReserverTest.php
+++ b/test/Resque/Tests/Reserver/AbstractReserverTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Resque\Tests\Reserver;
+
+use Resque\Reserver\ReserverInterface;
+use Resque;
+
+abstract class AbstractReserverTest extends \Resque_Tests_TestCase
+{
+    /** @var string */
+    protected $reserverName;
+
+    /**
+     * Gets a reserver instance configured with the given queues.
+     *
+     * @param array $queues
+     * @return ReserverInstance
+     */
+    abstract protected function getReserver(array $queues = array());
+
+    public function testGetName()
+    {
+        $this->assertEquals($this->reserverName, $this->getReserver()->getName());
+    }
+
+    public function testGetQueuesReturnsConfiguredQueues()
+    {
+        $queues = array(
+            'queue_' . rand(1, 100),
+            'queue_' . rand(101, 200),
+            'queue_' . rand(201, 300),
+        );
+        $this->assertEquals($queues, $this->getReserver($queues)->getQueues());
+    }
+
+    public function testGetQueuesWithAsterixQueueReturnsAllQueuesFromRedisInSortedOrder()
+    {
+        $queues = array(
+            'queue_b',
+            'queue_c',
+            'queue_d',
+            'queue_a',
+        );
+
+        // register queues in redis
+        foreach ($queues as $queue) {
+            Resque::redis()->sadd('queues', $queue);
+        }
+
+        $expected = array(
+            'queue_a',
+            'queue_b',
+            'queue_c',
+            'queue_d',
+        );
+
+        $this->assertEquals($expected, $this->getReserver(array('*'))->getQueues());
+    }
+}

--- a/test/Resque/Tests/Reserver/BlockingListPopReserverTest.php
+++ b/test/Resque/Tests/Reserver/BlockingListPopReserverTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Resque\Tests\Reserver;
+
+use Resque\Reserver\BlockingListPopReserver;
+use Resque;
+
+/**
+ * BlockingListPopReserver behaves the same as QueueOrderReserver but with different underlying implementation.
+ */
+class BlockingListPopReserverTest extends QueueOrderReserverTest
+{
+    protected $reserverName = 'BlockingListPopReserver';
+
+    protected function getReserver(array $queues = array(), $timeout = 1)
+    {
+        return new BlockingListPopReserver(new \Resque_Log(), $queues, $timeout);
+    }
+
+    public function testWaitAfterReservationAttemptReturnsTrue()
+    {
+        $this->assertFalse($this->getReserver()->waitAfterReservationAttempt());
+    }
+
+    public function testReserveCallsBlpopWithTimeout()
+    {
+        $timeout = rand(1, 100);
+
+        $queues = array(
+            'high',
+            'medium',
+            'low',
+        );
+
+        $redisQueues = array(
+            'queue:high',
+            'queue:medium',
+            'queue:low',
+        );
+
+        $payload = array('class' => 'Test_Job');
+        $item = array('resque:queue:high', json_encode($payload));
+
+        $redis = $this->getMockBuilder('\Resque_Redis')
+            ->disableOriginalConstructor()
+            ->setMethods(['__call'])
+            ->getMock();
+
+        $redis
+            ->expects($this->once())
+            ->method('__call')
+            ->with($this->equalTo('blpop'), $this->equalTo(array($redisQueues, $timeout)))
+            ->will($this->returnValue($item));
+
+        $originalRedis = Resque::$redis;
+
+        Resque::$redis = $redis;
+
+        $job = $this->getReserver($queues, $timeout)->reserve();
+        $this->assertEquals('high', $job->queue);
+        $this->assertEquals($payload, $job->payload);
+
+        Resque::$redis = $originalRedis;
+    }
+}

--- a/test/Resque/Tests/Reserver/BlockingListPopReserverTest.php
+++ b/test/Resque/Tests/Reserver/BlockingListPopReserverTest.php
@@ -22,6 +22,42 @@ class BlockingListPopReserverTest extends QueueOrderReserverTest
         $this->assertFalse($this->getReserver()->waitAfterReservationAttempt());
     }
 
+    public function testReserverWhenNoJobsEnqueuedReturnsNull()
+    {
+        $queues = array(
+            'queue_1',
+            'queue_2',
+            'queue_3',
+        );
+
+        $redisQueues = array(
+            'queue:queue_1',
+            'queue:queue_2',
+            'queue:queue_3',
+        );
+
+        // hhvm doesn't respect the timeout arg for blpop, so we need to mock this command
+        // https://github.com/facebook/hhvm/issues/6286
+        $redis = $this->getMockBuilder('\Resque_Redis')
+            ->disableOriginalConstructor()
+            ->setMethods(['__call'])
+            ->getMock();
+
+        $redis
+            ->expects($this->once())
+            ->method('__call')
+            ->with($this->equalTo('blpop'), $this->equalTo(array($redisQueues, 1)))
+            ->will($this->returnValue(null));
+
+        $originalRedis = Resque::$redis;
+
+        Resque::$redis = $redis;
+
+        $this->assertNull($this->getReserver($queues)->reserve());
+
+        Resque::$redis = $originalRedis;
+    }
+
     public function testReserveCallsBlpopWithTimeout()
     {
         $timeout = rand(1, 100);

--- a/test/Resque/Tests/Reserver/QueueOrderReserverTest.php
+++ b/test/Resque/Tests/Reserver/QueueOrderReserverTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Resque\Tests\Reserver;
+
+use Resque\Reserver\QueueOrderReserver;
+use Resque;
+
+class QueueOrderReserverTest extends AbstractReserverTest
+{
+    protected $reserverName = 'QueueOrderReserver';
+
+    protected function getReserver(array $queues = array())
+    {
+        return new QueueOrderReserver(new \Resque_Log(), $queues);
+    }
+
+    public function testWaitAfterReservationAttemptReturnsTrue()
+    {
+        $this->assertTrue($this->getReserver()->waitAfterReservationAttempt());
+    }
+
+    public function testReserverWhenNoJobsEnqueuedReturnsNull()
+    {
+        $queues = array(
+            'queue_1',
+            'queue_2',
+            'queue_3',
+        );
+        $this->assertNull($this->getReserver($queues)->reserve());
+    }
+
+    public function testReserveReservesJobsInSpecifiedQueueOrder()
+    {
+        $queues = array(
+            'high',
+            'medium',
+            'low',
+        );
+        $reserver = $this->getReserver($queues);
+
+        // Queue the jobs in a different order
+        Resque::enqueue('low', 'Low_Job_1');
+        Resque::enqueue('high', 'High_Job_1');
+        Resque::enqueue('medium', 'Medium_Job_1');
+        Resque::enqueue('medium', 'Medium_Job_2');
+        Resque::enqueue('high', 'High_Job_2');
+        Resque::enqueue('low', 'Low_Job_2');
+
+        // Now check we get the jobs back in the right order
+        $job = $reserver->reserve();
+        $this->assertEquals('high', $job->queue);
+        $this->assertEquals('High_Job_1', $job->payload['class']);
+
+        $job = $reserver->reserve();
+        $this->assertEquals('high', $job->queue);
+        $this->assertEquals('High_Job_2', $job->payload['class']);
+
+        $job = $reserver->reserve();
+        $this->assertEquals('medium', $job->queue);
+        $this->assertEquals('Medium_Job_1', $job->payload['class']);
+
+        $job = $reserver->reserve();
+        $this->assertEquals('medium', $job->queue);
+        $this->assertEquals('Medium_Job_2', $job->payload['class']);
+
+        $job = $reserver->reserve();
+        $this->assertEquals('low', $job->queue);
+        $this->assertEquals('Low_Job_1', $job->payload['class']);
+
+        $job = $reserver->reserve();
+        $this->assertEquals('low', $job->queue);
+        $this->assertEquals('Low_Job_2', $job->payload['class']);
+    }
+}

--- a/test/Resque/Tests/Reserver/RandomQueueOrderReserverTest.php
+++ b/test/Resque/Tests/Reserver/RandomQueueOrderReserverTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Resque\Tests\Reserver;
+
+use Resque\Reserver\RandomQueueOrderReserver;
+use Resque;
+
+class RandomQueueOrderReserverTest extends \Resque_Tests_TestCase
+{
+    protected function getReserver(array $queues = array())
+    {
+        return new RandomQueueOrderReserver(new \Resque_Log(), $queues);
+    }
+
+    public function testGetName()
+    {
+        $this->assertEquals('RandomQueueOrderReserver', $this->getReserver()->getName());
+    }
+
+    public function testWaitAfterReservationAttemptReturnsTrue()
+    {
+        $this->assertTrue($this->getReserver()->waitAfterReservationAttempt());
+    }
+
+    private function assertQueuesAreShuffled(RandomQueueOrderReserver $reserver, array $queues)
+    {
+        // retrieve the queues 20 times
+        $shuffledQueues = array();
+        for ($x = 0; $x < 20; $x++) {
+            $shuffledQueues[] = $reserver->getQueues();
+        }
+
+        $ordered = 0;
+        foreach ($shuffledQueues as $shuffled) {
+            // check if the order
+            if ($shuffled === $queues) {
+                $ordered++;
+            }
+
+            // check that the shuffled queues contain all the right elements though
+            sort($shuffled);
+            $this->assertEquals($queues, $shuffled);
+        }
+
+        // if all the shuffled queues were actually returned in sorted order then the shuffling is (unlikely) to be working
+        $this->assertNotEquals(20, $ordered, "queues were ordered 20 times; queues not shuffled correctly");
+    }
+
+    public function testGetQueuesReturnsConfiguredQueuesInShuffledOrder()
+    {
+        $queues = array(
+            'queue_a',
+            'queue_b',
+            'queue_c',
+            'queue_d',
+            'queue_e',
+            'queue_f',
+        );
+
+        $reserver = $this->getReserver($queues);
+
+        $this->assertQueuesAreShuffled($reserver, $queues);
+    }
+
+    public function testGetQueuesWithAsterixQueueReturnsAllQueuesFromRedisInShuffledOrder()
+    {
+        $queues = array(
+            'queue_a',
+            'queue_b',
+            'queue_c',
+            'queue_d',
+            'queue_e',
+            'queue_f',
+        );
+
+        // register queues in redis
+        foreach ($queues as $queue) {
+            Resque::redis()->sadd('queues', $queue);
+        }
+
+        $reserver = $this->getReserver(array('*'));
+
+        $this->assertQueuesAreShuffled($reserver, $queues);
+    }
+
+    public function testReserverWhenNoJobsEnqueuedReturnsNull()
+    {
+        $queues = array(
+            'queue_1',
+            'queue_2',
+            'queue_3',
+        );
+        $this->assertNull($this->getReserver($queues)->reserve());
+    }
+
+    public function testReserveReservesJobsFromRandomQueue()
+    {
+        $queues = array(
+            'queue_a',
+            'queue_b',
+            'queue_c',
+            'queue_d',
+            'queue_e',
+            'queue_f',
+        );
+
+        $reserver = $this->getReserver($queues);
+
+        $jobsPerQueue = 5;
+
+        // enqueue a bunch of jobs in each queue
+        foreach ($queues as $queue) {
+            for ($x = 0; $x < $jobsPerQueue; $x++) {
+                $queuesForAllJobs[] = $queue;
+                Resque::enqueue($queue, 'Test_Job');
+            }
+        }
+
+        $totalJobs = count($queues) * $jobsPerQueue;
+
+        // track the queue for each reserved job
+        $reservedQueues = array();
+        for ($x = 0; $x < $totalJobs; $x++) {
+            $job = $reserver->reserve();
+            $this->assertNotNull($job);
+            $reservedQueues[] = $job->queue;
+        }
+
+        // if jobs are reserved randomly, then $queueOrder shouldn't be ordered
+        $orderedQueues = $reservedQueues;
+        sort($orderedQueues);
+        $this->assertNotEquals($orderedQueues, $reservedQueues, "queues were ordered; queues not shuffled correctly");
+    }
+}

--- a/test/Resque/Tests/Reserver/ReserverFactoryTest.php
+++ b/test/Resque/Tests/Reserver/ReserverFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Resque\Tests\Reserver;
+
+use Resque\Reserver\ReserverFactory;
+use Resque;
+
+class ReserverFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    private function getFactory()
+    {
+        return new ReserverFactory(new \Resque_Log());
+    }
+
+    /**
+     * @expectedException Resque\Reserver\UnknownReserverException
+     * @expectedExceptionMessage Unknown reserver 'foo'
+     */
+    public function testCreateReserverFromNameThrowsExceptionForUnknownReserver()
+    {
+        $this->getFactory()->createReserverFromName('foo', array());
+    }
+
+    public function createReserverFromNameDataProvider()
+    {
+        return array(
+            array('queue_order', '\Resque\Reserver\QueueOrderReserver'),
+            array('RANDOM_QUEUE_ORDER', '\Resque\Reserver\RandomQueueOrderReserver'),
+            array('Blocking_List_Pop', '\Resque\Reserver\BlockingListPopReserver'),
+        );
+    }
+
+    /**
+     * @dataProvider createReserverFromNameDataProvider
+     */
+    public function testCreateReserverFromNameCreatesExpectedReserver($name, $expectedReserver)
+    {
+        $queues = array(
+            'queue_a',
+            'queue_b',
+            'queue_c',
+            'queue_d',
+        );
+
+        $reserver = $this->getFactory()->createReserverFromName($name, $queues);
+        $this->assertInstanceOf($expectedReserver, $reserver);
+
+        // account for shuffling by RandomQueueOrderReserver
+        $actualQueues = $reserver->getQueues();
+        sort($actualQueues);
+
+        $this->assertEquals($queues, $actualQueues);
+    }
+
+    public function testCreateDefaultReserverCreatesExpectedReserver()
+    {
+        $reserver = $this->getFactory()->createDefaultReserver(array());
+        $this->assertInstanceOf('\Resque\Reserver\QueueOrderReserver', $reserver);
+    }
+}

--- a/test/Resque/Tests/Reserver/ReserverFactoryTest.php
+++ b/test/Resque/Tests/Reserver/ReserverFactoryTest.php
@@ -57,4 +57,55 @@ class ReserverFactoryTest extends \PHPUnit_Framework_TestCase
         $reserver = $this->getFactory()->createDefaultReserver(array());
         $this->assertInstanceOf('\Resque\Reserver\QueueOrderReserver', $reserver);
     }
+
+    public function createReserverFromEnvironmentDataProvider()
+    {
+        return array(
+            array(array('BLOCKING=1'), '\Resque\Reserver\BlockingListPopReserver'),
+            array(array('BLOCKING=0', 'RESERVER=random_queue_order'), '\Resque\Reserver\RandomQueueOrderReserver'),
+            array(array('BLOCKING=', 'RESERVER=random_queue_order'), '\Resque\Reserver\RandomQueueOrderReserver'),
+            array(array('RESERVER=Queue_Order'), '\Resque\Reserver\QueueOrderReserver'),
+            array(array(), '\Resque\Reserver\QueueOrderReserver'),
+        );
+    }
+
+    /**
+     * @dataProvider createReserverFromEnvironmentDataProvider
+     */
+    public function testCreateReserverFromEnvironmentCreatesExpectedReserver($env, $expectedReserver)
+    {
+        $queues = array(
+            'queue_a',
+            'queue_b',
+            'queue_c',
+            'queue_d',
+        );
+
+        foreach ($env as $var) {
+            putenv($var);
+        }
+
+        $reserver = $this->getFactory()->createReserverFromEnvironment($queues);
+        $this->assertInstanceOf($expectedReserver, $reserver);
+
+        // account for shuffling by RandomQueueOrderReserver
+        $actualQueues = $reserver->getQueues();
+        sort($actualQueues);
+
+        $this->assertEquals($queues, $actualQueues);
+
+        putenv('BLOCKING');
+        putenv('RESERVER');
+    }
+
+    /**
+     * @expectedException Resque\Reserver\UnknownReserverException
+     * @expectedExceptionMessage Unknown reserver 'foobar'
+     */
+    public function testCreateReserverFromEnvironmentThrowsExceptionForUnknownReserver()
+    {
+        putenv('RESERVER=foobar');
+        $this->getFactory()->createReserverFromEnvironment(array());
+        putenv('RESERVER');
+    }
 }

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -9,6 +9,8 @@
 
 $loader = require __DIR__ . '/../vendor/autoload.php';
 
+use Resque\Reserver\ReserverFactory;
+
 define('TEST_MISC', realpath(__DIR__ . '/misc/'));
 define('REDIS_CONF', TEST_MISC . '/redis.conf');
 
@@ -35,6 +37,9 @@ if(!preg_match('#^\s*port\s+([0-9]+)#m', $config, $matches)) {
 }
 
 Resque::setBackend('localhost:' . $matches[1]);
+
+$reserverFactory = new ReserverFactory(new Resque_Log());
+Resque_Worker::setReserverFactory($reserverFactory);
 
 // Shutdown
 function killRedis($pid)

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -8,7 +8,6 @@
  */
 
 $loader = require __DIR__ . '/../vendor/autoload.php';
-$loader->add('Resque_Tests', __DIR__);
 
 define('TEST_MISC', realpath(__DIR__ . '/misc/'));
 define('REDIS_CONF', TEST_MISC . '/redis.conf');


### PR DESCRIPTION
Currently php-resque is capable of reserving jobs in two ways:
1. The default: Iterate through each queue in the order they are specified, processing all jobs in each queue before moving to the next
2. If `BLOCKING=1` is configured in the environment: The redis `blpop` command is used to do a blocking wait for a job to be enqueued on the configured queues. The order of processing is the same as above.

The behaviour of processing a queue entirely before moving to the next is restrictive. Additionally, if resque is configured to dynamically retrieve the available queues (by specifying `QUEUE=*`), then there is even less capability to prioritise as the retrieved queues are sorted alphabetically.

We have resque workers configured to process multiple queues but we consider them all equal priority. There is no way to configure this right now and it means that a single queue can dominate all the workers entirely, ignoring all others until it is processed. We occasionally experience surges where a queue may be loaded with 10's of thousands (or even more) of jobs which be result in a substantial delay on being able to process the other queues.

This PR introduces the concept of a Reserver (via `ReserverInterface`). A reserver exposes a `reserve()` method which is called by the `Resque_Worker`. Various behaviours can then be implemented in the `reserve()` method, such as to allow more fair queue processing for example.

Three Reservers are implemented:
- `QueueOrderReserver` - This reimplements the default behaviour described above, processing a higher priority queue entirely before moving to the next.
- `BlockListPopReserver` - This reimplements the behaviour that is toggled by specifying `BLOCKING=1`.
- `RandomQueueOrderReserver` - Shuffles the list of queues on each call to `reserve()`. This is a simple way to allow an equal amount of processing on all the queues.

New and interesting ways of reservation could be implemented in the future such as:
- Oldest job first -  inspect all the queues and find the job with the oldest `enqueue_time`

`ReserverInterface` is now a required dependency of `Resque_Worker` and is supplied in its constructor. The `$blocking` parameter to the `work()` and `reserve()` methods are removed.

A reserver is chosen in `bin/resque` based off the environment configuration:
- `BLOCKING` - A non empty value will select the `BlockListPopReserver`
- `RESERVER` - The name of any implemented reserver can be specified in snake case format, eg. `queue_order`, `random_queue_order`, `blocking_list_pop`

If neither is specified, the default `QueueOrderReserver` is used.

While I've tested this a fair bit myself, it would be great if others could give this some verification also.