### PR TITLE
Use is_callable instead of method_exists to check for setup/teardown

### DIFF
--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -187,13 +187,13 @@ class Resque_Job
 			Resque_Event::trigger('beforePerform', $this);
 
 			$instance = $this->getInstance();
-			if(method_exists($instance, 'setUp')) {
+			if(is_callable([$instance, 'setUp'])) {
 				$instance->setUp();
 			}
 
 			$instance->perform();
 
-			if(method_exists($instance, 'tearDown')) {
+			if(is_callable([$instance, 'tearDown'])) {
 				$instance->tearDown();
 			}
 


### PR DESCRIPTION
`method_exists` will return true even if an object has a protected method; calling it from Resque will then fail. `is_callable` only returns true when the method both exists and can be called externally.