### PR TITLE
allow users to use a credis native setup

### DIFF
--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -116,8 +116,8 @@ class Resque_Redis
 			if (is_array($server)) {
 				$this->driver = new Credis_Cluster($server);
 			}
-			else if (is_object($client)) {
-				$this->driver = $client;
+			else if (is_object($server)) {
+				$this->driver = $server;
 			}
 			else {
 				list($host, $port, $dsnDatabase, $user, $password, $options) = self::parseDsn($server);


### PR DESCRIPTION
... instead of testing an unused variable

this change allows us to pass a credis_cluster object as $server and thus use a preconfigured sentinel setup.
and it is already tested in production

best regards.