### PR TITLE
sleep x seconds if no blocking queue was found

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -262,6 +262,11 @@ class Resque_Worker
 		}
 
 		if($blocking === true) {
+		    if(empty($queues)){
+                $this->logger->log(Psr\Log\LogLevel::INFO, 'No queue was found, sleeping for {interval}', array('interval' => $timeout));
+                usleep($timeout * 1000000);
+                return false;
+            }
 			$job = Resque_Job::reserveBlocking($queues, $timeout);
 			if($job) {
 				$this->logger->log(Psr\Log\LogLevel::INFO, 'Found job on {queue}', array('queue' => $job->queue));


### PR DESCRIPTION
`QUEUE=*` AND `BLOCKING` will crash workers sometimes, because there is no queue exists, when `Resque_Job::reserveBlocking($emptyQueues, $timeout)` was invoke, the following error will be shown:

> PHP Fatal error:  Uncaught CredisException: wrong number of arguments for 'blpop' command in /home/razon/Develop/Projects/php-resque/vendor/colinmollenhour/credis/Client.php:1167
Stack trace:
#0 /home/razon/Develop/Projects/php-resque/vendor/colinmollenhour/credis/Client.php(905): Credis_Client->read_reply('blpop')
#1 /home/razon/Develop/Projects/php-resque/lib/Resque/Redis.php(249): Credis_Client->__call('blpop', Array)
#2 /home/razon/Develop/Projects/php-resque/lib/Resque.php(178): Resque_Redis->__call('blpop', Array)
#3 /home/razon/Develop/Projects/php-resque/lib/Resque/Job.php(112): Resque::blpop(Array, 5)
#4 /home/razon/Develop/Projects/php-resque/lib/Resque/Worker.php(270): Resque_Job::reserveBlocking(Array, 5)
#5 /home/razon/Develop/Projects/php-resque/lib/Resque/Worker.php(165): Resque_Worker->reserve(true, 5)
#6 /home/razon/Develop/Projects/php-resque/bin/resque(109): Resque_Worker->work(5, true)
#7 {main}


## Reproduce

1. FLUSHALL redis database - In order to clear the set `prefix:queues`.
2. EXEC `BLOCKING=1 VERBOSE=1 COUNT=2 QUEUE=* bin/resque`